### PR TITLE
fixing infinite loop in the script

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -86,7 +86,8 @@ else
                 shift
                 ;;
             *)
-                shift
+                echo "Unsupported flag: " $1
+                exit 1
                 ;;
         esac
     done

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -85,6 +85,9 @@ else
                 cross=true
                 shift
                 ;;
+            *)
+                shift
+                ;;
         esac
     done
     cd ~/node


### PR DESCRIPTION
when an argument is passed which does not match any of the cases, the script will go to an infinite loop.
Adding a default case to consume the argument. 