### PR TITLE
Draft scripts for running and debugging java cucumebr tests locally

### DIFF
--- a/scripts/debugTest.sh
+++ b/scripts/debugTest.sh
@@ -45,6 +45,10 @@ source $(dirname $0)/shared.sh
                 cross=true
                 shift
                 ;;
+             *)
+                echo "Unsupported flag: " $1
+                exit 1
+                ;;
         esac
     done
     cd ~/node

--- a/scripts/debugTest.sh
+++ b/scripts/debugTest.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# call from parent directory; scripts/test.sh
+
+rm -r ~/node/network
+
+source $(dirname $0)/shared.sh
+    rungo=false
+    runjava=false
+    runjs=false
+    runpy=false
+    cross=false
+
+    while [ $# -gt 0 ]
+    do
+        case "$1" in
+            -h|--help)
+                echo "Use no flags to run all tests"
+                echo " "
+                echo "Options:"
+                echo "-h, --help"
+                echo "    --go             run go SDK tests"
+                echo "    --java           run java SDK tests"
+                echo "    --js             run js SDK tests"
+                echo "    --py             run py SDK tests"
+                echo "    --cross          include crosstests if not running all tests"
+                exit 0
+                ;;
+            --go*)
+                rungo=true
+                shift
+                ;;
+            --java*)
+                runjava=true
+                shift
+                ;;
+            --js*)
+                runjs=true
+                shift
+                ;;
+            --py*)
+                runpy=true
+                shift
+                ;;
+            --cross*)
+                cross=true
+                shift
+                ;;
+        esac
+    done
+    cd ~/node
+    ./goal network create -n network -r network -t template.json
+    INDEXER_DIR=~/node/$(ls -d network/Node/network*)
+    KMD_DIR=$(ls -d network/Node/kmd*)
+    export KMD_DIR=$(basename $KMD_DIR)
+    cd -
+    cp network_config/config.json ~/node/network/Node
+    cd ~/node
+    ./goal network start -r network
+    ./update.sh -d network/Node
+    cd -
+
+    if $cross
+    then
+        mkdir temp
+    fi
+    if $rungo
+    then
+        cp -r features/. go_godog/src/features
+        ~/node/goal kmd start -d ~/node/network/Node
+        cd go_godog/src
+        if $cross
+        then
+            go test
+        else
+            go test --godog.tags=~@crosstest
+        fi
+        goexitcode=$?
+        cd ../..
+    else
+        if $cross
+        then
+            cp -r features/. go_godog/src/features
+            ~/node/goal kmd start -d ~/node/network/Node -t 0
+            cd go_godog/src
+            go test --godog.tags=@crosstest
+            goexitcode=$?
+            cd ../..
+        else
+            goexitcode=0
+        fi
+    fi
+
+    if $runjava
+    then
+        cp -r features/. java_cucumber/src/test/resources/java_cucumber
+        cd java_cucumber
+        if $cross
+        then
+            ~/node/goal kmd start -d ~/node/network/Node -t 0
+            mvn test -q # change to "pretty" in cucumberoptions if verbose
+        else
+            mvn test -q -Dcucumber.options="--tags \"not @crosstest\""
+        fi
+        javaexitcode=$?
+        cd ..
+    else
+        if $cross
+        then
+            cp -r features/. java_cucumber/src/test/resources/java_cucumber
+            ~/node/goal kmd start -d ~/node/network/Node -t 0 
+            cd java_cucumber
+            mvn test -q -Dcucumber.options="--tags \"@crosstest\""
+            javaexitcode=$?
+            cd ..
+        else
+            javaexitcode=0
+        fi
+    fi
+
+echo Press enter when debugging finished ... 
+read 
+echo Shutting down...
+
+    
+    if $cross
+    then
+        rm -r temp
+    fi
+
+cd ~/node
+./goal kmd stop -d network/Node
+./goal network stop -r network
+./goal network delete -r network
+
+if [ $goexitcode -eq 0 ] && [ $javaexitcode -eq 0 ] && [ $jsexitcode -eq 0 ] && [ $pyexitcode -eq 0 ]
+then
+    exit 0
+else
+    exit 1
+fi

--- a/scripts/localSetup.sh
+++ b/scripts/localSetup.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+go=false
+java=false
+js=false
+py=false
+
+case "$1" in
+    --go*)
+        go=true
+        ;;
+    --java*)
+        java=true
+        ;;
+    --js*)
+        js=true
+        ;;
+    --py*)
+        py=true
+        ;;
+esac
+
+go get github.com/DATA-DOG/godog/cmd/godog
+if ! $go
+then
+    go get -u github.com/algorand/go-algorand-sdk/...
+fi
+
+
+if $py
+then
+    pip3 install $TRAVIS_BUILD_DIR -q
+else
+    pyenv global 3.7.1
+    pip3 install git+https://github.com/algorand/py-algorand-sdk/ -q
+fi
+pip3 install behave -q
+
+# ensure correct nodejs version (>=10) if running on travis
+source $(dirname $0)/shared.sh
+ensure_nodejs_version
+
+cd js_cucumber
+npm install --silent
+if $js
+then
+    npm install $TRAVIS_BUILD_DIR --silent
+fi
+
+cd ../java_cucumber
+if $java
+then
+    cd $TRAVIS_BUILD_DIR
+    mvn package -q -DskipTests
+    ALGOSDK_VERSION=$(mvn -q -Dexec.executable=echo  -Dexec.args='${project.version}' --non-recursive exec:exec)
+    cd -
+    find "${TRAVIS_BUILD_DIR}/target" -type f -name "*.jar" -exec mvn install:install-file -q -Dfile={} -DpomFile="${TRAVIS_BUILD_DIR}/pom.xml" \;
+else
+    echo "Enter the full path to java-algorand-sdk"
+    read -r line
+    echo "Using: "  $line
+    cp -r  $line /tmp/
+    cd /tmp/java-algorand-sdk
+    mvn package -q -DskipTests
+    ALGOSDK_VERSION=$(mvn -q -Dexec.executable=echo  -Dexec.args='${project.version}' --non-recursive exec:exec)
+    cd -
+    find /tmp/java-algorand-sdk/target -type f -name "*.jar" -exec mvn install:install-file -q -Dfile={} -DpomFile="/tmp/java-algorand-sdk/pom.xml" \;
+    rm -rf /tmp/java-algorand-sdk
+fi
+mvn versions:use-dep-version -DdepVersion=$ALGOSDK_VERSION -Dincludes=com.algorand:algosdk -DforceVersion=true -q
+
+
+# get algorand tools; comment this section out if you already have this
+cd ..
+mkdir ~/inst
+# this is the link for linux; change this if on mac or windows
+curl -L https://github.com/algorand/go-algorand-doc/blob/master/downloads/installers/linux_amd64/install_master_linux-amd64.tar.gz?raw=true -o ~/inst/installer.tar.gz
+tar -xf ~/inst/installer.tar.gz -C ~/inst
+~/inst/update.sh -i -c stable -p ~/node -d ~/node/data -n
+
+# don't comment this out; tests depend on the specific network setup
+cp network_config/template.json ~/node


### PR DESCRIPTION
These are instructions for running java cucumber tests locally or in a debugger.

Run scripts/localSetup.sh to setup the environment.
The script will require as input the full path to java-algorand-sdk.
When prompted by the script, enter the full path to java-algorand-sdk in the command line and press Enter.
The provided location will be used as the source code under test of the java sdk.
Note: run localSetup.sh without any flags. The behavior is undefined with flags.

Run debugTest.sh to run the tests locally with the following flags.
./scripts/debugTest.sh --java --cross

To debug in a debugger, comment the line:
Then run the script. When prompted for: Press enter when debugging finished ...
Run the tests in the debugger (RunCucumberTest.java).
Press Enter to shutdown the testing environment.

Notes:
In java_cucumber/src/test/java/java_cucumber/Stepdefs.java
If KMD_DIR environment variable is not set properly, the follwing change might be needed:
Change from:
data_dir_path += System.getenv("KMD_DIR") + "/";
To:
data_dir_path += "kmd-v0.5" + "/";