### PR TITLE
Test changes for Pull Request 42

### DIFF
--- a/java_cucumber/src/test/java/java_cucumber/Stepdefs.java
+++ b/java_cucumber/src/test/java/java_cucumber/Stepdefs.java
@@ -243,13 +243,13 @@ public class Stepdefs {
                     to,
                     close
             );
-        Account.transactionWithSuggestedFeePerByte(txn, txn.fee);
+        Account.setFeeByFeePerByte(txn, txn.fee);
     }
 
     @When("I create the key registration transaction")
     public void createKeyregTxn() throws NoSuchAlgorithmException, JsonProcessingException, IOException{
         txn = new Transaction(pk, fee, fv, lv, note, gen, gh, votepk, vrfpk, votefst, votelst, votekd);
-        Account.transactionWithSuggestedFeePerByte(txn, txn.fee);
+        Account.setFeeByFeePerByte(txn, txn.fee);
     }
 
     @Given("multisig addresses {string}")
@@ -277,7 +277,7 @@ public class Stepdefs {
             to,
             close
         );
-        Account.transactionWithSuggestedFeePerByte(txn, txn.fee);
+        Account.setFeeByFeePerByte(txn, txn.fee);
     }
 
     @When("I sign the multisig transaction with the private key")
@@ -572,7 +572,7 @@ public class Stepdefs {
                     params.getGenesisID(),
                     new Digest(params.getGenesishashb64())
             );
-        Account.transactionWithSuggestedFeePerByte(txn, txn.fee);
+        Account.setFeeByFeePerByte(txn, txn.fee);
         pk = new Address(accounts.get(0));
     }
 
@@ -601,7 +601,7 @@ public class Stepdefs {
                     params.getGenesisID(),
                     new Digest(params.getGenesishashb64())
             );
-        Account.transactionWithSuggestedFeePerByte(txn, txn.fee);
+        Account.setFeeByFeePerByte(txn, txn.fee);
         pk = new Address(accounts.get(0));
     }
 

--- a/java_cucumber/src/test/java/java_cucumber/Stepdefs.java
+++ b/java_cucumber/src/test/java/java_cucumber/Stepdefs.java
@@ -243,13 +243,13 @@ public class Stepdefs {
                     to,
                     close
             );
-        txn = Account.transactionWithSuggestedFeePerByte(txn, txn.fee);
+        Account.transactionWithSuggestedFeePerByte(txn, txn.fee);
     }
 
     @When("I create the key registration transaction")
     public void createKeyregTxn() throws NoSuchAlgorithmException, JsonProcessingException, IOException{
         txn = new Transaction(pk, fee, fv, lv, note, gen, gh, votepk, vrfpk, votefst, votelst, votekd);
-        txn = Account.transactionWithSuggestedFeePerByte(txn, txn.fee);
+        Account.transactionWithSuggestedFeePerByte(txn, txn.fee);
     }
 
     @Given("multisig addresses {string}")
@@ -277,7 +277,7 @@ public class Stepdefs {
             to,
             close
         );
-        txn = Account.transactionWithSuggestedFeePerByte(txn, txn.fee);
+        Account.transactionWithSuggestedFeePerByte(txn, txn.fee);
     }
 
     @When("I sign the multisig transaction with the private key")
@@ -572,7 +572,7 @@ public class Stepdefs {
                     params.getGenesisID(),
                     new Digest(params.getGenesishashb64())
             );
-        txn = Account.transactionWithSuggestedFeePerByte(txn, txn.fee);
+        Account.transactionWithSuggestedFeePerByte(txn, txn.fee);
         pk = new Address(accounts.get(0));
     }
 
@@ -601,7 +601,7 @@ public class Stepdefs {
                     params.getGenesisID(),
                     new Digest(params.getGenesishashb64())
             );
-        txn = Account.transactionWithSuggestedFeePerByte(txn, txn.fee);
+        Account.transactionWithSuggestedFeePerByte(txn, txn.fee);
         pk = new Address(accounts.get(0));
     }
 


### PR DESCRIPTION
Pull Request 42 Asset send and accept transactions and other changes
fixes the interface: Account.transactionWithSuggestedFeePerByte
by eliminating the return value.
https://github.com/algorand/java-algorand-sdk/pull/42

The change to Stepdefs.java is needed to reflect this change.
Currently PR 42 is failng:
https://travis-ci.com/algorand/java-algorand-sdk/builds/132403770
