### PR TITLE
Run go-generate for go-algorand-sdk

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -25,6 +25,7 @@ go get github.com/DATA-DOG/godog/cmd/godog
 if ! $go
 then
     go get -u github.com/algorand/go-algorand-sdk/...
+    go generate github.com/algorand/go-algorand-sdk/...
 fi
 
 


### PR DESCRIPTION
* go-algorand-sdk now has autogenerated TEAL lang spec that is
  generated from json as part of build process
* by design go-get does not run go-generate
* need to run go-generate as part of installation