### PR TITLE
Target js master in js tests.

### DIFF
--- a/js_cucumber/package.json
+++ b/js_cucumber/package.json
@@ -11,7 +11,7 @@
   "license": "ISC",
   "devDependencies": {},
   "dependencies": {
-    "algosdk": "github:algorand/js-algorand-sdk#057e882b839d682a5cd07ad799a747d340132cfe",
+    "algosdk": "github:algorand/js-algorand-sdk#master",
     "cucumber": "^5.1.0",
     "xmlhttprequest": "^1.8.0"
   }


### PR DESCRIPTION
## Summary
This changes the JS tests' `package.json` to target the tip of `js-algorand-sdk#master` rather than a specific commit.

### Testing
Tested on my machine, waiting on Travis results to double check. 