### PR TITLE
Adding strictEmptyAddressChecking parameter with value false to cucumber test

### DIFF
--- a/java_cucumber/src/test/java/java_cucumber/Stepdefs.java
+++ b/java_cucumber/src/test/java/java_cucumber/Stepdefs.java
@@ -1008,7 +1008,7 @@ public class Stepdefs {
                 new Address(this.creator), // manager
                 new Address(), // reserve
                 new Address(), // freeze
-                new Address()); // clawback
+                new Address(), false); // clawback
         Account.setFeeByFeePerByte(tx, tx.fee);
         this.txn = tx;
         this.expectedParams = tx.assetParams;        


### PR DESCRIPTION
createAssetConfigureTransaction has a new parameter strictEmptyAddressChecking. 
Updating the test and passing value false to the parameter. 

Ref:
https://github.com/algorand/java-algorand-sdk/pull/59