### PR TITLE
Use stable installer instead of nightly.

### DIFF
--- a/scripts/docker/setup.py
+++ b/scripts/docker/setup.py
@@ -163,11 +163,6 @@ def setup_algod(config_file):
     """
     Download and install algod.
     """
-    # mkdir -p ~/inst
-    # curl -L https://algorand-releases.s3.amazonaws.com/channel/nightly/install_nightly_linux-amd64_1.0.288.tar.gz -o ~/inst/installer.tar.gz
-    # tar -xf ~/inst/installer.tar.gz -C ~/inst
-    # ~/inst/update.sh -i -c $CHANNEL -p $BIN_DIR -d $BIN_DIR/data -n
-    
     # Parse config file...
     with open(config_file) as f:
         l = [line.split("=") for line in f.readlines()]
@@ -175,7 +170,7 @@ def setup_algod(config_file):
     home = expanduser('~')
     os.makedirs("%s/inst" % home, exist_ok=True)
     print('downloading updater...')
-    url='https://algorand-releases.s3.amazonaws.com/channel/nightly/install_nightly_linux-amd64_1.0.288.tar.gz'
+    url='https://algorand-releases.s3.amazonaws.com/channel/stable/install_stable_linux-amd64_2.0.4.tar.gz'
     updater_tar='%s/inst/installer.tar.gz' % home
     filedata = urllib.request.urlretrieve(url, updater_tar)
     tar = tarfile.open(updater_tar)

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -82,6 +82,6 @@ source "$SCRIPTPATH/config_future"
 
 mkdir ~/inst
 # this is the link for linux; change this if on mac or windows
-curl -L https://algorand-releases.s3.amazonaws.com/channel/nightly/install_nightly_linux-amd64_1.0.288.tar.gz -o ~/inst/installer.tar.gz
+curl -L https://algorand-releases.s3.amazonaws.com/channel/stable/install_stable_linux-amd64_2.0.4.tar.gz -o ~/inst/installer.tar.gz
 tar -xf ~/inst/installer.tar.gz -C ~/inst
 ~/inst/update.sh -i -c $CHANNEL -p $BIN_DIR -d $BIN_DIR/data -n


### PR DESCRIPTION
We want to start deleting old nightly build, so this URL needs to be updated.