### PR TITLE
remove registerpartkeys and shutdown tests

### DIFF
--- a/features/unit/v2algodclient_paths.feature
+++ b/features/unit/v2algodclient_paths.feature
@@ -3,22 +3,6 @@ Feature: Algod REST API v2
     Given mock server recording request paths
   # SendRaw, Status, Supply, SuggestedParams, and PendingTransactionsInformation omitted - the path never mutates, they're constant
 
-  Scenario Outline: Shutdown
-    When we make a Shutdown call with timeout <timeout>
-    Then expect the path used to be "<path>"
-    Examples:
-      |path                   | timeout |
-      |/v2/shutdown           | 0 |
-      |/v2/shutdown?timeout=1 | 1 |
-
-  # Scenario Outline: Register Participation Keys
-  #   When we make a Register Participation Keys call against account "<account>" fee <fee> dilution <dilution> lastvalidround <lastvalid> and nowait "<nowait>"
-  #   Then expect the path used to be "<path>"
-  #   Examples:
-  #     |path                                                                                        | account                                                       | fee | dilution | lastvalid | nowait|
-  #     |/v2/register-participation-keys/7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q  | 7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q    | 0   | 0        | 0         | false |
-  #     |/v2/register-participation-keys/7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q?fee=1001&key-dilution=23&round-last-valid=12345&no-wait=true  | 7ZUECA7HFLZTXENRV24SHLU4AVPUTMTTDUFUBNBD64C73F3UHRTHAIOF6Q    | 1001   | 23        | 12345         | true |
-
   Scenario Outline: Pending Transaction Information
     When we make a Pending Transaction Information against txid "<txid>" with format "<format>"
     Then expect the path used to be "<path>"

--- a/features/unit/v2algodclient_responses.feature
+++ b/features/unit/v2algodclient_responses.feature
@@ -1,21 +1,5 @@
 Feature: Algod REST API v2
 
-  Scenario Outline: Shutdown response
-    Given mock http responses in "<jsonfiles>" loaded from "<directory>"
-    When we make any Shutdown call
-    Then expect error string to contain "<err>"
-    Examples:
-      |jsonfiles |directory                  |err|
-      |empty.json|v2algodclient_responsejsons|nil|
-
-  Scenario Outline: Register Participation Keys response
-    Given mock http responses in "<jsonfiles>" loaded from "<directory>"
-    When we make any Register Participation Keys call
-    Then expect error string to contain "<err>"
-    Examples:
-      |jsonfiles |directory                  |err|
-      |empty.json|v2algodclient_responsejsons|nil|
-
   Scenario Outline: Pending Transaction Information response
     Given mock http responses in "<jsonfiles>" loaded from "<directory>"
     When we make any Pending Transaction Information call


### PR DESCRIPTION
Per review feedback in go-sdk and js-sdk, this changeset will remove registerpartkeys and shutdown tests.