### PR TITLE
More reliable shutdown script

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ version: '3'
 services:
   algod:
     image: "sdk-harness-algod"
+    container_name: sdk-harness-algod
     build:
       context: .
       dockerfile: ./docker/algod/Dockerfile
@@ -13,6 +14,7 @@ services:
       - sdk-harness
   indexer:
     image: "sdk-harness-indexer"
+    container_name: sdk-harness-indexer
     build:
       context: .
       dockerfile: ./docker/indexer/Dockerfile
@@ -26,6 +28,7 @@ services:
 
   indexer-db:
     image: "postgres"
+    container_name: sdk-harness-postgres
     volumes:
       - ./docker/indexer/init-scripts:/docker-entrypoint-initdb.d
     ports:

--- a/scripts/down.sh
+++ b/scripts/down.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
-set -e
-
 rootdir=`dirname $0`
-pushd $rootdir/..
+pushd $rootdir/.. > /dev/null
 
 docker-compose down
 docker-compose rm --force
+
+# In case a graceful shutdown fails, bring them down the hard way.
+#docker kill $(docker ps -f name="sdk-harness")
+docker ps -f name="sdk-harness" -q | xargs -r docker kill

--- a/scripts/interactive.sh
+++ b/scripts/interactive.sh
@@ -2,7 +2,7 @@
 set -e
 
 rootdir=`dirname $0`
-pushd $rootdir/..
+pushd $rootdir/.. > /dev/null
 
 ./scripts/down.sh
 docker-compose rm --force

--- a/scripts/restart.sh
+++ b/scripts/restart.sh
@@ -5,7 +5,7 @@
 set -e
 
 rootdir=`dirname $0`
-pushd $rootdir/..
+pushd $rootdir/.. > /dev/null
 
 # Make sure it isn't running
 ./scripts/down.sh

--- a/scripts/up.sh
+++ b/scripts/up.sh
@@ -2,7 +2,7 @@
 set -e
 
 rootdir=`dirname $0`
-pushd $rootdir/..
+pushd $rootdir/.. > /dev/null
 
 # Make sure it isn't running
 ./scripts/down.sh


### PR DESCRIPTION
I think everyone has hit this issue by now. If you run `up.sh` in one project then `down.sh` in another fails. This fixes the problem in 2 ways:
- gives the containers a consistent name prefixed with sdk-harness, rather than prefixing the root directory.
- If a graceful shutdown fails, forcefully shuts down any containers containing sdk-harness in their name.