### PR TITLE
Add scripts for local algod/kmd startup

### DIFF
--- a/scripts/local/down.sh
+++ b/scripts/local/down.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+TEMP=$(dirname "$(mktemp -u)")
+NETWORK_NAME="sdknet"
+NETWORK_DIR="/$TEMP/$NETWORK_NAME/"
+
+goal kmd stop -d "$NETWORK_DIR/Primary"
+goal network stop -r "$NETWORK_DIR"
+goal network delete -r "$NETWORK_DIR"

--- a/scripts/local/up.sh
+++ b/scripts/local/up.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+REPO_ROOT="$( cd "$(dirname "$0")" || exit; pwd -P )"/../..
+TEMP=$(dirname "$(mktemp -u)")
+NETWORK_NAME="sdknet"
+NETWORK_DIR="$TEMP/$NETWORK_NAME/"
+
+goal network stop -r "$NETWORK_DIR"
+rm -rf "$NETWORK_DIR"
+goal network create -n "$NETWORK_NAME" -r "$NETWORK_DIR" -t "$REPO_ROOT/network_config/future_template.json"
+
+jq '. += {"Archival":true,"isIndexerActive":true,"EnableDeveloperAPI":true} | .EndpointAddress="127.0.0.1:60000"' \
+  < "$NETWORK_DIR/Primary/config.json" \
+  > "$NETWORK_DIR/Primary/config.json.new"
+rm "$NETWORK_DIR/Primary/config.json"
+mv "$NETWORK_DIR/Primary/config.json.new" "$NETWORK_DIR/Primary/config.json"
+
+echo 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' > "$NETWORK_DIR/Primary/algod.token"
+echo 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' > "$NETWORK_DIR/Primary/kmd-v0.5/kmd.token"
+echo '{"address":"127.0.0.1:60001", "allowed_origins":["*"]}' > "$NETWORK_DIR/Primary/kmd-v0.5/kmd_config.json"
+
+goal network start -r "$NETWORK_DIR"
+goal kmd start -d "$NETWORK_DIR/Primary"


### PR DESCRIPTION
Running docker locally not great for development:
* hard to debug
* might need different environment rather than docker creates
* building algod twice (locally to check changes, and the same in docker is not time efficient)

Scripts `up.sh` and `down.sh` for local development eliminate above problems.