### PR TITLE
Update dryrun test with base64 key

### DIFF
--- a/features/integration/dryrun_testing.feature
+++ b/features/integration/dryrun_testing.feature
@@ -35,9 +35,9 @@ Feature: Dryrun Testing
     Given dryrun test case with <program> of type <kind>
     Then global delta assert with <key>, <value> and <action> is failed
     Scenarios:
-      | program                     | kind     | key        | action | value  |
+      | program                     | kind     | key            | action | value  |
       | "programs/globalwrite.teal" | "clearp" | "Ynl0ZXNrZXk=" | 1      | "test" |
-      | "programs/globalwrite.teal" | "approv" | "aW50a2V5"   | 2      | "12"   |
+      | "programs/globalwrite.teal" | "approv" | "aW50a2V5"     | 2      | "12"   |
 
   Scenario Outline: Dryrun test case with local state delta assert succeed
     Given dryrun test case with <program> of type <kind>

--- a/features/integration/dryrun_testing.feature
+++ b/features/integration/dryrun_testing.feature
@@ -25,26 +25,26 @@ Feature: Dryrun Testing
     Given dryrun test case with <program> of type <kind>
     Then global delta assert with <key>, <value> and <action> is succeed
     Scenarios:
-      | program                     | kind     | key        | action | value      |
-      | "programs/globalwrite.teal" | "approv" | "byteskey" | 1      | "dGVzdA==" |
-      | "programs/globalwrite.teal" | "approv" | "intkey"   | 2      | "11"       |
-      | "programs/globalwrite.teal" | "clearp" | "byteskey" | 1      | "dGVzdA==" |
-      | "programs/globalwrite.teal" | "clearp" | "intkey"   | 2      | "11"       |
+      | program                     | kind     | key            | action | value      |
+      | "programs/globalwrite.teal" | "approv" | "Ynl0ZXNrZXk=" | 1      | "dGVzdA==" |
+      | "programs/globalwrite.teal" | "approv" | "aW50a2V5"     | 2      | "11"       |
+      | "programs/globalwrite.teal" | "clearp" | "Ynl0ZXNrZXk=" | 1      | "dGVzdA==" |
+      | "programs/globalwrite.teal" | "clearp" | "aW50a2V5"     | 2      | "11"       |
 
   Scenario Outline: Dryrun test case with global state delta assert failed
     Given dryrun test case with <program> of type <kind>
     Then global delta assert with <key>, <value> and <action> is failed
     Scenarios:
       | program                     | kind     | key        | action | value  |
-      | "programs/globalwrite.teal" | "clearp" | "byteskey" | 1      | "test" |
-      | "programs/globalwrite.teal" | "approv" | "intkey"   | 2      | "12"   |
+      | "programs/globalwrite.teal" | "clearp" | "Ynl0ZXNrZXk=" | 1      | "test" |
+      | "programs/globalwrite.teal" | "approv" | "aW50a2V5"   | 2      | "12"   |
 
   Scenario Outline: Dryrun test case with local state delta assert succeed
     Given dryrun test case with <program> of type <kind>
     Then local delta assert for <addr> of accounts <index> with <key>, <value> and <action> is succeed
     Scenarios:
-      | program                    | kind     | addr                                                         | index | key        | action | value      |
-      | "programs/localwrite.teal" | "approv" | "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ" | 0     | "byteskey" | 1      | "dGVzdA==" |
-      | "programs/localwrite.teal" | "approv" | "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ" | 0     | "intkey"   | 2      | "11"       |
-      | "programs/localwrite.teal" | "clearp" | "6Z3C3LDVWGMX23BMSYMANACQOSINPFIRF77H7N3AWJZYV6OH6GWTJKVMXY" | 1     | "byteskey" | 1      | "dGVzdA==" |
-      | "programs/localwrite.teal" | "clearp" | "6Z3C3LDVWGMX23BMSYMANACQOSINPFIRF77H7N3AWJZYV6OH6GWTJKVMXY" | 1     | "intkey"   | 2      | "11"       |
+      | program                    | kind     | addr                                                         | index | key            | action | value      |
+      | "programs/localwrite.teal" | "approv" | "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ" | 0     | "Ynl0ZXNrZXk=" | 1      | "dGVzdA==" |
+      | "programs/localwrite.teal" | "approv" | "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ" | 0     | "aW50a2V5"     | 2      | "11"       |
+      | "programs/localwrite.teal" | "clearp" | "6Z3C3LDVWGMX23BMSYMANACQOSINPFIRF77H7N3AWJZYV6OH6GWTJKVMXY" | 1     | "Ynl0ZXNrZXk=" | 1      | "dGVzdA==" |
+      | "programs/localwrite.teal" | "clearp" | "6Z3C3LDVWGMX23BMSYMANACQOSINPFIRF77H7N3AWJZYV6OH6GWTJKVMXY" | 1     | "aW50a2V5"     | 2      | "11"       |


### PR DESCRIPTION
The keys are now base64 encoded, update the dryrun test.