### PR TITLE
Update ubuntu image

### DIFF
--- a/docker/algod/channel/Dockerfile
+++ b/docker/algod/channel/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.10
+FROM ubuntu:20.04
 
 ARG CHANNEL=nightly
 ENV BIN_DIR="$HOME/node"

--- a/docker/algod/channel/Dockerfile
+++ b/docker/algod/channel/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:19.10
+FROM ubuntu:20.10
 
 ARG CHANNEL=nightly
 ENV BIN_DIR="$HOME/node"


### PR DESCRIPTION
`apt-get update` appears to be failing on ubuntu 19.10 because it's reached end of life. This PR updates the base image to ubuntu 20.04.