### PR TITLE
Pin Indexer Versions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,10 +85,10 @@ services:
       SNAPSHOT_FILE: /tmp/dataset2.tar.bz2
       CONNECTION_STRING: "host=indexer-db port=5432 user=algorand password=harness dbname=dataset2 sslmode=disable"
 
-  # Create/Delete/Rewards Branch using dataset2
-  indexer-23x-2:
-    image: "sdk-harness-indexer-23x"
-    container_name: sdk-harness-indexer-23x
+  # Create/Delete/Rewards Branch using dataset1
+  indexer-23x-1:
+    image: "sdk-harness-indexer-23x-1"
+    container_name: sdk-harness-indexer-23x-1
     build:
       context: .
       dockerfile: ./docker/indexer/Dockerfile
@@ -103,8 +103,29 @@ services:
       - sdk-harness
     environment:
       TYPE: "snapshot"
+      SNAPSHOT_FILE: /tmp/dataset1.tar.bz2
+      CONNECTION_STRING: "host=indexer-db port=5432 user=algorand password=harness dbname=dataset1-2 sslmode=disable"
+
+  # Create/Delete/Rewards Branch using dataset2
+  indexer-23x-2:
+    image: "sdk-harness-indexer-23x-2"
+    container_name: sdk-harness-indexer-23x-2
+    build:
+      context: .
+      dockerfile: ./docker/indexer/Dockerfile
+      args:
+        URL: "https://github.com/algorand/indexer"
+        BRANCH: "master"
+        SHA: "a849ec0c8b7c6683a9518ac28005205bf11a7e59"
+    ports:
+      - 59996:8980
+    restart: unless-stopped
+    networks:
+      - sdk-harness
+    environment:
+      TYPE: "snapshot"
       SNAPSHOT_FILE: /tmp/dataset2.tar.bz2
-      CONNECTION_STRING: "host=indexer-db port=5432 user=algorand password=harness dbname=dataset2 sslmode=disable"
+      CONNECTION_STRING: "host=indexer-db port=5432 user=algorand password=harness dbname=dataset2-2 sslmode=disable"
 
   indexer-db:
     image: "postgres"
@@ -118,7 +139,7 @@ services:
     environment:
       POSTGRES_USER: algorand
       POSTGRES_PASSWORD: harness
-      POSTGRES_MULTIPLE_DATABASES: live, dataset1, dataset2
+      POSTGRES_MULTIPLE_DATABASES: live, dataset1, dataset2, dataset1-2, dataset2-2
 
 networks:
   sdk-harness:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,8 +43,8 @@ services:
     volumes:
       - genesis-file:/genesis-file
 
-  # develop branch dataset1
-  indexer-release:
+  # Applications Branch using dataset1
+  indexer-221-1:
     image: "sdk-harness-indexer-release"
     container_name: sdk-harness-indexer-release
     build:
@@ -53,7 +53,7 @@ services:
       args:
         URL: "https://github.com/algorand/indexer"
         BRANCH: "master"
-        #SHA: "d5bbaf6190d27118fd8823194b4053fb01859f13"
+        SHA: "a30878e3669310c30a2b916fb41511516b906c9a"
     ports:
       - 59999:8980
     restart: unless-stopped
@@ -65,7 +65,7 @@ services:
       CONNECTION_STRING: "host=indexer-db port=5432 user=algorand password=harness dbname=dataset1 sslmode=disable"
 
   # Applications Branch using dataset2
-  indexer-applications:
+  indexer-221-2:
     image: "sdk-harness-indexer-applications"
     container_name: sdk-harness-indexer-applications
     build:
@@ -73,9 +73,31 @@ services:
       dockerfile: ./docker/indexer/Dockerfile
       args:
         URL: "https://github.com/algorand/indexer"
-        BRANCH: "develop"
+        BRANCH: "master"
+        SHA: "a30878e3669310c30a2b916fb41511516b906c9a"
     ports:
       - 59998:8980
+    restart: unless-stopped
+    networks:
+      - sdk-harness
+    environment:
+      TYPE: "snapshot"
+      SNAPSHOT_FILE: /tmp/dataset2.tar.bz2
+      CONNECTION_STRING: "host=indexer-db port=5432 user=algorand password=harness dbname=dataset2 sslmode=disable"
+
+  # Create/Delete/Rewards Branch using dataset2
+  indexer-23x-2:
+    image: "sdk-harness-indexer-23x"
+    container_name: sdk-harness-indexer-23x
+    build:
+      context: .
+      dockerfile: ./docker/indexer/Dockerfile
+      args:
+        URL: "https://github.com/algorand/indexer"
+        BRANCH: "master"
+        SHA: "a849ec0c8b7c6683a9518ac28005205bf11a7e59"
+    ports:
+      - 59997:8980
     restart: unless-stopped
     networks:
       - sdk-harness

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -104,7 +104,7 @@ services:
     environment:
       TYPE: "snapshot"
       SNAPSHOT_FILE: /tmp/dataset1.tar.bz2
-      CONNECTION_STRING: "host=indexer-db port=5432 user=algorand password=harness dbname=dataset1-2 sslmode=disable"
+      CONNECTION_STRING: "host=indexer-db port=5432 user=algorand password=harness dbname=dataset1_2 sslmode=disable"
 
   # Create/Delete/Rewards Branch using dataset2
   indexer-23x-2:
@@ -125,7 +125,7 @@ services:
     environment:
       TYPE: "snapshot"
       SNAPSHOT_FILE: /tmp/dataset2.tar.bz2
-      CONNECTION_STRING: "host=indexer-db port=5432 user=algorand password=harness dbname=dataset2-2 sslmode=disable"
+      CONNECTION_STRING: "host=indexer-db port=5432 user=algorand password=harness dbname=dataset2_2 sslmode=disable"
 
   indexer-db:
     image: "postgres"
@@ -139,7 +139,7 @@ services:
     environment:
       POSTGRES_USER: algorand
       POSTGRES_PASSWORD: harness
-      POSTGRES_MULTIPLE_DATABASES: live, dataset1, dataset2, dataset1-2, dataset2-2
+      POSTGRES_MULTIPLE_DATABASES: live, dataset1, dataset2, dataset1_2, dataset2_2
 
 networks:
   sdk-harness:

--- a/docker/algod/channel/Dockerfile
+++ b/docker/algod/channel/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:19.10
+FROM ubuntu:20.04
 
 ARG CHANNEL=nightly
 ENV BIN_DIR="$HOME/node"

--- a/features/integration/indexer.feature
+++ b/features/integration/indexer.feature
@@ -7,6 +7,8 @@ Feature: Indexer Integration Tests
   Background:
     Given indexer client 1 at "localhost" port 59999 with token "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
     Given indexer client 2 at "localhost" port 59998 with token "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    Given indexer client 3 at "localhost" port 59997 with token "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    Given indexer client 4 at "localhost" port 59996 with token "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 
   @indexer
   Scenario Outline: /health
@@ -116,6 +118,11 @@ Feature: Indexer Integration Tests
       | 1       | 9        | 0           | 0           | 1     | 1            | OSY2LBBSYJXOBAO6T5XGMGAJM77JVPQ7OLRR5J3HEPC3QWBTQZNWSEZA44 | false     | 999931337000 |
       | 1       | 9        | 68663000    | 0           | 0     | 1            | OSY2LBBSYJXOBAO6T5XGMGAJM77JVPQ7OLRR5J3HEPC3QWBTQZNWSEZA44 | false     | 999931337000 |
       | 1       | 9        | 0           | 68663001    | 0     | 1            | ZBBRQD73JH5KZ7XRED6GALJYJUXOMBBP3X2Z2XFA4LATV3MUJKKMKG7SHA | false     | 68663000     |
+      # these pick up deleted asset balances in dataset 1 + 2.3.x.
+      #| 3       | 9        | 0           | 0           | 0     | 2            | OSY2LBBSYJXOBAO6T5XGMGAJM77JVPQ7OLRR5J3HEPC3QWBTQZNWSEZA44 | false     | 999931337000 |
+      #| 3       | 9        | 0           | 0           | 1     | 1            | OSY2LBBSYJXOBAO6T5XGMGAJM77JVPQ7OLRR5J3HEPC3QWBTQZNWSEZA44 | false     | 999931337000 |
+      #| 3       | 9        | 0           | 0           | 1     | 1            | OSY2LBBSYJXOBAO6T5XGMGAJM77JVPQ7OLRR5J3HEPC3QWBTQZNWSEZA44 | false     | 999931337000 |
+      #| 3       | 9        | 0           | 68663001    | 0     | 1            | ZBBRQD73JH5KZ7XRED6GALJYJUXOMBBP3X2Z2XFA4LATV3MUJKKMKG7SHA | false     | 68663000     |
 
 
   @indexer
@@ -127,6 +134,8 @@ Feature: Indexer Integration Tests
     Examples:
       | indexer | asset-id | currency-gt | currency-lt | limit | num-accounts | account                                                    | is-frozen | amount   |
       | 1       | 9        | 0           | 0           | 1     | 1            | ZBBRQD73JH5KZ7XRED6GALJYJUXOMBBP3X2Z2XFA4LATV3MUJKKMKG7SHA | false     | 68663000 |
+      # this picks up a deleted asset balance
+      #| 3       | 9        | 1           | 0           | 1     | 1            | ZBBRQD73JH5KZ7XRED6GALJYJUXOMBBP3X2Z2XFA4LATV3MUJKKMKG7SHA | false     | 68663000 |
 
     #####################
 
@@ -148,6 +157,8 @@ Feature: Indexer Integration Tests
       | 1       | 9        | 0     | 68663000    | 0           | 1   | 0               | 0            | 0       | 999899126000    | OSY2LBBSYJXOBAO6T5XGMGAJM77JVPQ7OLRR5J3HEPC3QWBTQZNWSEZA44 | 999899126000 | Offline | sig  |
       | 1       | 9        | 0     | 0           | 68663001    | 1   | 0               | 0            | 0       | 998000          | ZBBRQD73JH5KZ7XRED6GALJYJUXOMBBP3X2Z2XFA4LATV3MUJKKMKG7SHA | 998000       | Offline | lsig |
       | 1       | 0        | 0     | 798999      | 799001      | 1   | 0               | 0            | 0       | 799000          | RRHDAJKO5HQBLHPCVK6K7U54LENDIP2JKM3RNRYX2G254VUXBRQD35CK4E | 799000       | Offline | msig |
+      # this picks up a deleted account
+      | 3       | 9        | 0     | 1           | 68663001    | 1   | 0               | 0            | 0       | 998000          | ZBBRQD73JH5KZ7XRED6GALJYJUXOMBBP3X2Z2XFA4LATV3MUJKKMKG7SHA | 998000       | Offline | lsig |
 
   #
   # /accounts - online


### PR DESCRIPTION
Avoid surprise failures from Indexer features the SDKs don't support yet by pinning Indexer versions.