### PR TITLE
Update indexer dockerfile to build with new go-algorand dependency

### DIFF
--- a/docker/indexer/Dockerfile
+++ b/docker/indexer/Dockerfile
@@ -6,7 +6,8 @@ ARG SHA=""
 
 RUN echo "Installing from source. ${URL} -- ${BRANCH} -- ${SHA}"
 
-RUN apk add --no-cache git bzip2 make bash
+RUN apk update && apk add --no-cache --update\
+        alpine-sdk git bzip2 make bash libtool autoconf automake boost-dev musl-dev
 
 # Install indexer binaries.
 RUN git clone --single-branch --branch "${BRANCH}" "${URL}" /opt/indexer

--- a/docker/indexer/Dockerfile
+++ b/docker/indexer/Dockerfile
@@ -6,7 +6,7 @@ ARG SHA=""
 
 RUN echo "Installing from source. ${URL} -- ${BRANCH} -- ${SHA}"
 
-RUN apk update && apk add --no-cache --update\
+RUN apk update && apk add --no-cache --update \
         alpine-sdk git bzip2 make bash libtool autoconf automake boost-dev musl-dev
 
 # Install indexer binaries.


### PR DESCRIPTION
Indexer now depends on go-algorand, so our indexer docker image needs to have some go-algorand dependencies in it.