### PR TITLE
Fix error message for dynamic cost exceeded

### DIFF
--- a/features/integration/applications.feature
+++ b/features/integration/applications.feature
@@ -12,7 +12,7 @@ Feature: Applications
       Given I create a new transient account and fund it with 100000000 microalgos.
       # Application create with extra pages should succeed with expected message. 
       And I build an application transaction with the transient account, the current application, suggested params, operation "create", approval-program "programs/big_app_program.teal.tok", clear-program "programs/big_app_program.teal.tok", global-bytes <global-bytes>, global-ints 0, local-bytes <local-bytes>, local-ints 0, app-args "", foreign-apps "", foreign-assets "", app-accounts "", extra-pages 3
-      And I sign and submit the transaction, saving the txid. If there is an error it is "logic eval error: pc=704 dynamic cost budget of 700 exceeded".
+      And I sign and submit the transaction, saving the txid. If there is an error it is "logic eval error: pc=704 dynamic cost budget exceeded, executing intc_1: remaining budget is 700 but program cost was 701".
       # Create application
       # depends on the transient account, and also the application id.
       # Use suggested params


### PR DESCRIPTION
Recently, we merged a [change](https://github.com/algorand/go-algorand/issues/2711) that modified an error message. This commit updates the resulting error message. 

Currently, the tests fail because of this discrepancy: 
```
exception: error string logic eval error: pc=704 dynamic cost budget of 700 exceeded not in actual error {"message":"TransactionPool.Remember: transaction SCICRALBCE3LWZB67KICOMJ362QPMDSF73GVKE7VU7QLT7VYESMA: logic eval error: pc=704 dynamic cost budget exceeded, executing intc_1: remaining budget is 700 but program cost was 701"}
```