### PR TITLE
Upgrade algod and indexer images to Go 1.17

### DIFF
--- a/docker/algod/source/Dockerfile
+++ b/docker/algod/source/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16.11
+FROM golang:1.7
 
 ARG URL=https://github.com/algorand/go-algorand
 ARG BRANCH=master

--- a/docker/algod/source/Dockerfile
+++ b/docker/algod/source/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.7
+FROM golang:1.17
 
 ARG URL=https://github.com/algorand/go-algorand
 ARG BRANCH=master

--- a/docker/indexer/Dockerfile
+++ b/docker/indexer/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13.12-alpine
+FROM golang:1.17-alpine
 
 ARG URL=https://github.com/algorand/indexer
 ARG BRANCH=master


### PR DESCRIPTION
Updates algod and indexer images to support Go v1.17.  

Relates to these PRs:
* https://github.com/algorand/go-algorand/pull/3919
* https://github.com/algorand/indexer/pull/980