### PR TITLE
Assert that Atomic Transaction Composer's method adder checks for arg-length consistency

### DIFF
--- a/features/integration/abi.feature
+++ b/features/integration/abi.feature
@@ -18,15 +18,16 @@ Feature: ABI Interaction
     When I create the Method object from method signature "<method-signature>"
     And I create a new method arguments array.
     And I append the encoded arguments "<app-args>" to the method arguments array.
-    And I add a method call with the transient account, the current application, suggested params, on complete "noop", current transaction signer, current method arguments.
     # When "none" is provided for <none-or-exception-pattern> there should be no exception, otherwise, the error's message should satisfy the regex
-    Then the most recently added method call has an exception which satisfies "<none-or-exception-pattern>".
+    And I add a method call with the transient account, the current application, suggested params, on complete "noop", current transaction signer, current method arguments; any resulting exception satisfies the regex "<none-or-exception-pattern>".
 
     Examples:
       | method-signature         | app-args                               | none-or-exception-pattern |
       | add(uint64,uint64)uint64 | AAAAAAAAAAE=,AAAAAAAAAAI=              | none                      |
       | empty()void              |                                        | none                      |
+      | empty()void              | AAAAAAAAAAE=                           | number.*arguments         |
       | add(uint64,uint64)uint64 | AAAAAAAAAAE=,AAAAAAAAAAI=,AAAAAAAAAAI= | number.*arguments         |
+      | add(uint64,uint64)uint64 | AAAAAAAAAAE=                           | number.*arguments         |
 
   Scenario Outline: Method call execution with other transactions
     Given a new AtomicTransactionComposer

--- a/features/integration/abi.feature
+++ b/features/integration/abi.feature
@@ -12,6 +12,7 @@ Feature: ABI Interaction
     And I wait for the transaction to be confirmed.
     And I remember the new application ID.
 
+  @z
   Scenario Outline: Method call exceptions
     Given a new AtomicTransactionComposer
     # Create a payment method call with an address argument, and add it to the composer
@@ -19,7 +20,7 @@ Feature: ABI Interaction
     And I create a new method arguments array.
     And I append the encoded arguments "<app-args>" to the method arguments array.
     # When "none" is provided for <none-or-exception-pattern> there should be no exception, otherwise, the error's message should satisfy the regex:
-    And I add a method call with the transient account, the current application, suggested params, on complete "noop", current transaction signer, current method arguments; any resulting exception satisfies the regex "<none-or-exception-pattern>".
+    Then I add a method call with the transient account, the current application, suggested params, on complete "noop", current transaction signer, current method arguments; any resulting exception satisfies the regex "<none-or-exception-pattern>".
 
     Examples:
       | method-signature         | app-args                               | none-or-exception-pattern |

--- a/features/integration/abi.feature
+++ b/features/integration/abi.feature
@@ -23,12 +23,22 @@ Feature: ABI Interaction
     Then I add a method call with the transient account, the current application, suggested params, on complete "noop", current transaction signer, current method arguments; any resulting exception satisfies the regex "<none-or-exception-pattern>".
 
     Examples:
-      | method-signature         | app-args                               | none-or-exception-pattern |
-      | add(uint64,uint64)uint64 | AAAAAAAAAAE=,AAAAAAAAAAI=              | none                      |
-      | empty()void              |                                        | none                      |
-      | empty()void              | AAAAAAAAAAE=                           | number.*arguments         |
-      | add(uint64,uint64)uint64 | AAAAAAAAAAE=,AAAAAAAAAAI=,AAAAAAAAAAI= | number.*arguments         |
-      | add(uint64,uint64)uint64 | AAAAAAAAAAE=                           | number.*arguments         |
+      | method-signature                                                                                                  | app-args                                                                                   | none-or-exception-pattern |
+      | add(uint64,uint64)uint64                                                                                          | AAAAAAAAAAE=,AAAAAAAAAAI=                                                                  | none                      |
+      | empty()void                                                                                                       |                                                                                            | none                      |
+      | f15(string,string,string,string,string,string,string,string,string,string,string,string,string,string,string)void | AAFh,AAFi,AAFj,AAFk,AAFl,AAFm,AAFn,AAFo,AAFp,AAFq,AAFr,AAFs,AAFt,AAFu,AAFv                 | none                      |
+      | f16(uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8)void          | AA==,AQ==,Ag==,Aw==,BA==,BQ==,Bg==,Bw==,CA==,CQ==,Cg==,Cw==,DA==,DQ==,Dg==,Dw==            | none                      |
+      | f17(uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8)void    | AA==,AQ==,Ag==,Aw==,BA==,BQ==,Bg==,Bw==,CA==,CQ==,Cg==,Cw==,DA==,DQ==,Dg==,Dw==,Dw==       | none                      |
+      | add(uint64,uint64)uint64                                                                                          | AAAAAAAAAAE=,AAAAAAAAAAI=,AAAAAAAAAAI=                                                     | number.*arguments         |
+      | add(uint64,uint64)uint64                                                                                          | AAAAAAAAAAE=                                                                               | number.*arguments         |
+      | empty()void                                                                                                       | AAAAAAAAAAE=                                                                               | number.*arguments         |
+      | f15(string,string,string,string,string,string,string,string,string,string,string,string,string,string,string)void | AAFh,AAFi,AAFj,AAFk,AAFl,AAFm,AAFn,AAFo,AAFp,AAFq,AAFr,AAFs,AAFt,AAFu                      | number.*arguments         |
+      | f15(string,string,string,string,string,string,string,string,string,string,string,string,string,string,string)void | AAFh,AAFi,AAFj,AAFk,AAFl,AAFm,AAFn,AAFo,AAFp,AAFq,AAFr,AAFs,AAFt,AAFu,AAFu,AAFu            | number.*arguments         |
+      | f16(uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8)void          | AA==,AQ==,Ag==,Aw==,BA==,BQ==,Bg==,Bw==,CA==,CQ==,Cg==,Cw==,DA==,DQ==,Dg==                 | number.*arguments         |
+      | f16(uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8)void          | AA==,AQ==,Ag==,Aw==,BA==,BQ==,Bg==,Bw==,CA==,CQ==,Cg==,Cw==,DA==,DQ==,Dg==,Dw==,Dw==       | number.*arguments         |
+      | f17(uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8)void    | AA==,AQ==,Ag==,Aw==,BA==,BQ==,Bg==,Bw==,CA==,CQ==,Cg==,Cw==,DA==,DQ==,Dg==                 | number.*arguments         |
+      | f17(uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8)void    | AA==,AQ==,Ag==,Aw==,BA==,BQ==,Bg==,Bw==,CA==,CQ==,Cg==,Cw==,DA==,DQ==,Dg==,Dw==            | number.*arguments         |
+      | f17(uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8)void    | AA==,AQ==,Ag==,Aw==,BA==,BQ==,Bg==,Bw==,CA==,CQ==,Cg==,Cw==,DA==,DQ==,Dg==,Dw==,Dw==,Dw==  | number.*arguments         |
 
   Scenario Outline: Method call execution with other transactions
     Given a new AtomicTransactionComposer

--- a/features/integration/abi.feature
+++ b/features/integration/abi.feature
@@ -12,7 +12,6 @@ Feature: ABI Interaction
     And I wait for the transaction to be confirmed.
     And I remember the new application ID.
 
-  @z
   Scenario Outline: Method call exceptions
     Given a new AtomicTransactionComposer
     # Create a payment method call with an address argument, and add it to the composer

--- a/features/integration/abi.feature
+++ b/features/integration/abi.feature
@@ -18,7 +18,7 @@ Feature: ABI Interaction
     When I create the Method object from method signature "<method-signature>"
     And I create a new method arguments array.
     And I append the encoded arguments "<app-args>" to the method arguments array.
-    # When "none" is provided for <none-or-exception-pattern> there should be no exception, otherwise, the error's message should satisfy the regex
+    # When "none" is provided for <none-or-exception-pattern> there should be no exception, otherwise, the error's message should satisfy the regex:
     And I add a method call with the transient account, the current application, suggested params, on complete "noop", current transaction signer, current method arguments; any resulting exception satisfies the regex "<none-or-exception-pattern>".
 
     Examples:

--- a/features/integration/abi.feature
+++ b/features/integration/abi.feature
@@ -12,6 +12,22 @@ Feature: ABI Interaction
     And I wait for the transaction to be confirmed.
     And I remember the new application ID.
 
+  Scenario Outline: Method call exceptions
+    Given a new AtomicTransactionComposer
+    # Create a payment method call with an address argument, and add it to the composer
+    When I create the Method object from method signature "<method-signature>"
+    And I create a new method arguments array.
+    And I append the encoded arguments "<app-args>" to the method arguments array.
+    And I add a method call with the transient account, the current application, suggested params, on complete "noop", current transaction signer, current method arguments.
+    # When "none" is provided for <none-or-exception-pattern> there should be no exception, otherwise, the error's message should satisfy the regex
+    Then the most recently added method call has an exception which satisfies "<none-or-exception-pattern>".
+
+    Examples:
+      | method-signature         | app-args                               | none-or-exception-pattern |
+      | add(uint64,uint64)uint64 | AAAAAAAAAAE=,AAAAAAAAAAI=              | none                      |
+      | empty()void              |                                        | none                      |
+      | add(uint64,uint64)uint64 | AAAAAAAAAAE=,AAAAAAAAAAI=,AAAAAAAAAAI= | number.*arguments         |
+
   Scenario Outline: Method call execution with other transactions
     Given a new AtomicTransactionComposer
     # Create a pay transaction, create a TransactionSigner, and add it to the composer

--- a/features/integration/abi.feature
+++ b/features/integration/abi.feature
@@ -12,33 +12,6 @@ Feature: ABI Interaction
     And I wait for the transaction to be confirmed.
     And I remember the new application ID.
 
-  Scenario Outline: Method call exceptions
-    Given a new AtomicTransactionComposer
-    # Create a payment method call with an address argument, and add it to the composer
-    When I create the Method object from method signature "<method-signature>"
-    And I create a new method arguments array.
-    And I append the encoded arguments "<app-args>" to the method arguments array.
-    # When "none" is provided for <none-or-exception-pattern> there should be no exception, otherwise, the error's message should satisfy the regex:
-    Then I add a method call with the transient account, the current application, suggested params, on complete "noop", current transaction signer, current method arguments; any resulting exception satisfies the regex "<none-or-exception-pattern>".
-
-    Examples:
-      | method-signature                                                                                                  | app-args                                                                                   | none-or-exception-pattern |
-      | add(uint64,uint64)uint64                                                                                          | AAAAAAAAAAE=,AAAAAAAAAAI=                                                                  | none                      |
-      | empty()void                                                                                                       |                                                                                            | none                      |
-      | f15(string,string,string,string,string,string,string,string,string,string,string,string,string,string,string)void | AAFh,AAFi,AAFj,AAFk,AAFl,AAFm,AAFn,AAFo,AAFp,AAFq,AAFr,AAFs,AAFt,AAFu,AAFv                 | none                      |
-      | f16(uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8)void          | AA==,AQ==,Ag==,Aw==,BA==,BQ==,Bg==,Bw==,CA==,CQ==,Cg==,Cw==,DA==,DQ==,Dg==,Dw==            | none                      |
-      | f17(uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8)void    | AA==,AQ==,Ag==,Aw==,BA==,BQ==,Bg==,Bw==,CA==,CQ==,Cg==,Cw==,DA==,DQ==,Dg==,Dw==,Dw==       | none                      |
-      | add(uint64,uint64)uint64                                                                                          | AAAAAAAAAAE=,AAAAAAAAAAI=,AAAAAAAAAAI=                                                     | number.*arguments         |
-      | add(uint64,uint64)uint64                                                                                          | AAAAAAAAAAE=                                                                               | number.*arguments         |
-      | empty()void                                                                                                       | AAAAAAAAAAE=                                                                               | number.*arguments         |
-      | f15(string,string,string,string,string,string,string,string,string,string,string,string,string,string,string)void | AAFh,AAFi,AAFj,AAFk,AAFl,AAFm,AAFn,AAFo,AAFp,AAFq,AAFr,AAFs,AAFt,AAFu                      | number.*arguments         |
-      | f15(string,string,string,string,string,string,string,string,string,string,string,string,string,string,string)void | AAFh,AAFi,AAFj,AAFk,AAFl,AAFm,AAFn,AAFo,AAFp,AAFq,AAFr,AAFs,AAFt,AAFu,AAFu,AAFu            | number.*arguments         |
-      | f16(uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8)void          | AA==,AQ==,Ag==,Aw==,BA==,BQ==,Bg==,Bw==,CA==,CQ==,Cg==,Cw==,DA==,DQ==,Dg==                 | number.*arguments         |
-      | f16(uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8)void          | AA==,AQ==,Ag==,Aw==,BA==,BQ==,Bg==,Bw==,CA==,CQ==,Cg==,Cw==,DA==,DQ==,Dg==,Dw==,Dw==       | number.*arguments         |
-      | f17(uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8)void    | AA==,AQ==,Ag==,Aw==,BA==,BQ==,Bg==,Bw==,CA==,CQ==,Cg==,Cw==,DA==,DQ==,Dg==                 | number.*arguments         |
-      | f17(uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8)void    | AA==,AQ==,Ag==,Aw==,BA==,BQ==,Bg==,Bw==,CA==,CQ==,Cg==,Cw==,DA==,DQ==,Dg==,Dw==            | number.*arguments         |
-      | f17(uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8)void    | AA==,AQ==,Ag==,Aw==,BA==,BQ==,Bg==,Bw==,CA==,CQ==,Cg==,Cw==,DA==,DQ==,Dg==,Dw==,Dw==,Dw==  | number.*arguments         |
-
   Scenario Outline: Method call execution with other transactions
     Given a new AtomicTransactionComposer
     # Create a pay transaction, create a TransactionSigner, and add it to the composer

--- a/features/unit/atomic_transaction_composer.feature
+++ b/features/unit/atomic_transaction_composer.feature
@@ -171,6 +171,7 @@ Feature: Atomic Transaction Composer
     When I build the transaction group with the composer. If there is an error it is "zero group size error".
     Then The composer should have a status of "BUILDING".
   
+  @unit.atc_method_args
   Scenario Outline: Method call argument count validation
     Given a new AtomicTransactionComposer
     And suggested transaction parameters fee 1234, flat-fee "true", first-valid 9000, last-valid 9010, genesis-hash "Mf0h6zjkEIEZPtNM3zsrg+iHQFS0fZxhgr7w35I464M=", genesis-id "cucumbernet"

--- a/features/unit/atomic_transaction_composer.feature
+++ b/features/unit/atomic_transaction_composer.feature
@@ -170,3 +170,32 @@ Feature: Atomic Transaction Composer
     Given a new AtomicTransactionComposer
     When I build the transaction group with the composer. If there is an error it is "zero group size error".
     Then The composer should have a status of "BUILDING".
+  
+  Scenario Outline: Method call argument count validation
+    Given a new AtomicTransactionComposer
+    And suggested transaction parameters fee 1234, flat-fee "true", first-valid 9000, last-valid 9010, genesis-hash "Mf0h6zjkEIEZPtNM3zsrg+iHQFS0fZxhgr7w35I464M=", genesis-id "cucumbernet"
+    And I make a transaction signer for the signing account.
+    And an application id 42
+    When I create the Method object from method signature "<method-signature>"
+    And I create a new method arguments array.
+    And I append the encoded arguments "<app-args>" to the method arguments array.
+    # When "none" is provided for <none-or-exception-pattern> there should be no exception, otherwise, the error's message should satisfy the regex:
+    Then I add a method call with the signing account, the current application, suggested params, on complete "noop", current transaction signer, current method arguments; any resulting exception has key "<none-or-exception-key>".
+
+    Examples:
+      | method-signature                                                                                                  | app-args                                                                                   | none-or-exception-key     |
+      | add(uint64,uint64)uint64                                                                                          | AAAAAAAAAAE=,AAAAAAAAAAI=                                                                  | none                      |
+      | empty()void                                                                                                       |                                                                                            | none                      |
+      | f15(string,string,string,string,string,string,string,string,string,string,string,string,string,string,string)void | AAFh,AAFi,AAFj,AAFk,AAFl,AAFm,AAFn,AAFo,AAFp,AAFq,AAFr,AAFs,AAFt,AAFu,AAFv                 | none                      |
+      | f16(uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8)void          | AA==,AQ==,Ag==,Aw==,BA==,BQ==,Bg==,Bw==,CA==,CQ==,Cg==,Cw==,DA==,DQ==,Dg==,Dw==            | none                      |
+      | f17(uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8)void    | AA==,AQ==,Ag==,Aw==,BA==,BQ==,Bg==,Bw==,CA==,CQ==,Cg==,Cw==,DA==,DQ==,Dg==,Dw==,Dw==       | none                      |
+      | add(uint64,uint64)uint64                                                                                          | AAAAAAAAAAE=,AAAAAAAAAAI=,AAAAAAAAAAI=                                                     | argument_count_mismatch   |
+      | add(uint64,uint64)uint64                                                                                          | AAAAAAAAAAE=                                                                               | argument_count_mismatch   |
+      | empty()void                                                                                                       | AAAAAAAAAAE=                                                                               | argument_count_mismatch   |
+      | f15(string,string,string,string,string,string,string,string,string,string,string,string,string,string,string)void | AAFh,AAFi,AAFj,AAFk,AAFl,AAFm,AAFn,AAFo,AAFp,AAFq,AAFr,AAFs,AAFt,AAFu                      | argument_count_mismatch   |
+      | f15(string,string,string,string,string,string,string,string,string,string,string,string,string,string,string)void | AAFh,AAFi,AAFj,AAFk,AAFl,AAFm,AAFn,AAFo,AAFp,AAFq,AAFr,AAFs,AAFt,AAFu,AAFu,AAFu            | argument_count_mismatch   |
+      | f16(uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8)void          | AA==,AQ==,Ag==,Aw==,BA==,BQ==,Bg==,Bw==,CA==,CQ==,Cg==,Cw==,DA==,DQ==,Dg==                 | argument_count_mismatch   |
+      | f16(uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8)void          | AA==,AQ==,Ag==,Aw==,BA==,BQ==,Bg==,Bw==,CA==,CQ==,Cg==,Cw==,DA==,DQ==,Dg==,Dw==,Dw==       | argument_count_mismatch   |
+      | f17(uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8)void    | AA==,AQ==,Ag==,Aw==,BA==,BQ==,Bg==,Bw==,CA==,CQ==,Cg==,Cw==,DA==,DQ==,Dg==                 | argument_count_mismatch   |
+      | f17(uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8)void    | AA==,AQ==,Ag==,Aw==,BA==,BQ==,Bg==,Bw==,CA==,CQ==,Cg==,Cw==,DA==,DQ==,Dg==,Dw==            | argument_count_mismatch   |
+      | f17(uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8,uint8)void    | AA==,AQ==,Ag==,Aw==,BA==,BQ==,Bg==,Bw==,CA==,CQ==,Cg==,Cw==,DA==,DQ==,Dg==,Dw==,Dw==,Dw==  | argument_count_mismatch   |


### PR DESCRIPTION
# Method Adder arg-length Check Assertion

Adding a new integration test _Scenario Outline_ that asserts that when adding an ABI method via the Atomic Transaction Composer, a validity check is undertaken to ensure that the number of runtime args is the number that is expected by the method's signature. In particular, a new step is introduced, which is a variant of the "I add a method call with..." step family.

>  I add a method call with the signing account, the current application, suggested params, on complete "noop", current transaction signer, current method arguments; any resulting exception has key "{none-or-exception-key}".

Will not merge until all 4 SDK's implement the new step, or will at least add a new tag before merging.

## SDK Specific Situations

Please see #190 for some cursory investigations that were conducted on how each SDK's `AtomicTransactionComposer` asserts that the number of arguments provided to the app call, match the number according the method signature.