### PR TITLE
Updated Box path tests using new encoding scheme

### DIFF
--- a/features/unit/v2algodclient_paths.feature
+++ b/features/unit/v2algodclient_paths.feature
@@ -76,10 +76,10 @@ Feature: Algod REST API v2 Paths
     Then expect the path used to be "<path>"
     Examples:
       | path                                                | application-id | encoded-box-name     |
-      | /v2/applications/1234/box?name=b64%3AaGVsbG8%3D     | 1234           | b64:aGVsbG8= |
-      | /v2/applications/1234/box?name=b64%3A%2Fw%3D%3D     | 1234           | b64:/w==     |
-      | /v2/applications/1234/box?name=b64%3A8J%2BSqQ%3D%3D | 1234           | b64:8J+SqQ== |
-      | /v2/applications/1234/box?name=b64%3AYS96           | 1234           | b64:YS96     |
+      | /v2/applications/1234/box?name=b64%3AaGVsbG8%3D     | 1234           | b64:aGVsbG8=         |
+      | /v2/applications/1234/box?name=b64%3A%2Fw%3D%3D     | 1234           | b64:/w==             |
+      | /v2/applications/1234/box?name=b64%3A8J%2BSqQ%3D%3D | 1234           | b64:8J+SqQ==         |
+      | /v2/applications/1234/box?name=b64%3AYS96           | 1234           | b64:YS96             |
 
   @unit.algod.ledger_refactoring
   Scenario Outline: Account Information


### PR DESCRIPTION
This PR updates the box search API path tests using the new encoding scheme, which changes the API path and adds a query parameter to the request using the goal app-arg format (e.g. `b64:...`)

Tested using Python SDK and the corresponding go-algorand branch: https://github.com/algorand/py-algorand-sdk/pull/346/checks?check_run_id=7118265740