### PR TITLE
Boxes:  Point to newest go-algorand branch

### DIFF
--- a/.up-env
+++ b/.up-env
@@ -5,4 +5,4 @@ export CHANNEL="nightly"
 
 # Used when TYPE=source
 export ALGOD_URL="https://github.com/algorand/go-algorand"
-export ALGOD_BRANCH="feature/avm-box"
+export ALGOD_BRANCH="ahangsu/box-names-by-app-id"


### PR DESCRIPTION
Points to newer go-algorand branch that should be used until https://github.com/algorand/go-algorand/pull/4154 is merged.  When https://github.com/algorand/go-algorand/pull/4154 is merged, the PR can be reverted. 