### PR TITLE
Boxes: Point go-algorand to boxes_response_rework

### DIFF
--- a/.up-env
+++ b/.up-env
@@ -5,4 +5,4 @@ export CHANNEL="nightly"
 
 # Used when TYPE=source
 export ALGOD_URL="https://github.com/algorand/go-algorand"
-export ALGOD_BRANCH="feature/avm-box"
+export ALGOD_BRANCH="boxes_response_rework"


### PR DESCRIPTION
Extends #208 to point go-algorand branch to https://github.com/algorand/go-algorand/pull/4249.  Enables SDKs to make corresponding API changes.