### PR TITLE
Create unique address for rekeying scenarios

### DIFF
--- a/.up-env
+++ b/.up-env
@@ -1,4 +1,4 @@
-export TYPE="channel"
+export TYPE="source"
 
 # Used when TYPE=channel
 export CHANNEL="nightly"

--- a/features/integration/rekey.feature
+++ b/features/integration/rekey.feature
@@ -6,18 +6,19 @@ Feature: Sending transactions
     And wallet information
 
   Scenario Outline: Sending transactions
-    Given default transaction with parameters <amt> "<note>"
+    When I generate a key using kmd for rekeying
+    Given default transaction with parameters <amt> "<note>" and rekeying key
     When I get the private key
     And I add a rekeyTo field with address "<rekeyTo>"
     And I sign the transaction with the private key
     And I send the transaction
     Then the transaction should go through
-    Given default transaction with parameters <amt> "<note>"
+    Given default transaction with parameters <amt> "<note>" and rekeying key
     And mnemonic for private key "<mn>"
     And I sign the transaction with the private key
     And I send the transaction
     Then the transaction should go through
-    Given default transaction with parameters <amt> "<note>"
+    Given default transaction with parameters <amt> "<note>" and rekeying key
     When I get the private key
     And I add a rekeyTo field with the private key algorand address
     And mnemonic for private key "<mn>"


### PR DESCRIPTION
Creates a unique address for rekeying scenarios in order to isolate changes needed for successful dev mode network testing.

Prior to the PR, one of the base accounts is rekeyed.  Depending on test sequencing, other tests are liable to fail due to algod side effects stemming from rekeying.