### PR TITLE
Revert compile sourcemap

### DIFF
--- a/features/integration/compile.feature
+++ b/features/integration/compile.feature
@@ -28,4 +28,4 @@ Feature: Compile
     Then the resulting source map is the same as the json "<sourcemap>"
     Examples:
       | teal                | sourcemap                                   |
-      | programs/quine.teal | v2algodclient_responsejsons/sourcemap2.json |
+      | programs/quine.teal | v2algodclient_responsejsons/sourcemap.json |

--- a/features/integration/compile.feature
+++ b/features/integration/compile.feature
@@ -28,4 +28,4 @@ Feature: Compile
     Then the resulting source map is the same as the json "<sourcemap>"
     Examples:
       | teal                | sourcemap                                   |
-      | programs/quine.teal | v2algodclient_responsejsons/sourcemap.json |
+      | programs/quine.teal | v2algodclient_responsejsons/sourcemap.json  |

--- a/features/resources/v2algodclient_responsejsons/sourcemap2.json
+++ b/features/resources/v2algodclient_responsejsons/sourcemap2.json
@@ -1,1 +1,0 @@
-{"version":3,"sources":[],"names":[],"mapping":";AAOA;;;;;;;;;;;;;;;;;;;;;;;;;;;;AAQA;AASA;;;AAUA;;;AAWA;AAYA;;AAaA;AAcA;;;AAeA;AAgBA;AAiBA;;AAkBA;;AAmBA;AAoBA;AAqBA"}


### PR DESCRIPTION
This PR reverts the sourcemap.json file. This is a short term fix to pass builds.

Eventually, we need to remove the `mapping` field in the go-algorand API here: https://github.com/algorand/go-algorand/blob/31037ed403b76f708097b1eb37570d611132ca6e/data/transactions/logic/sourcemap.go#L40

There should be no changes to the SDKs since they parse the JSON response directly, but the corresponding test resource in `algorand-sdk-testing` should be changed to remove the `mapping` field.

Here are the changes in the SDK testing repo and the Py SDK repo to confirm that build are passing again:
https://github.com/algorand/algorand-sdk-testing/pull/192/files#diff-0a7ecfb6e41efcb68835b21de89d02950802a01db753ced46b1e1aad303a63deR31

Py SDK: https://app.circleci.com/pipelines/github/algorand/py-algorand-sdk/864/workflows/882405cc-dd70-463a-b188-f59c1670b662/jobs/3890