### PR TITLE
Remove v1 algod dependencies from cucumber tests 

### DIFF
--- a/features/integration/algod.feature
+++ b/features/integration/algod.feature
@@ -6,6 +6,9 @@ Feature: Algod
   Scenario: Node health
     Then the node should be healthy
 
+  Scenario: Ledger supply
+    Then I get the ledger supply
+
   Scenario: Version
     When I get versions with algod
     Then v2 should be in the versions

--- a/features/integration/algod.feature
+++ b/features/integration/algod.feature
@@ -1,48 +1,11 @@
 @algod
 Feature: Algod
   Background:
-    Given an algod client
+    Given an algod v2 client connected to "localhost" port 60000 with token "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 
   Scenario: Node health
     Then the node should be healthy
 
-  Scenario: Status check
-    Given a kmd client
-    And wallet information
-    When I get the status
-    And I get status after this block
-    Then I can get the block info
-
-  Scenario: Ledger supply
-    Then I get the ledger supply
-
-  Scenario: Getting transactions by address
-    Given a kmd client
-    And wallet information
-    Then I get transactions by address and round
-
-  Scenario: Getting transaction by ID
-    Given a kmd client
-    And wallet information
-    And default transaction with parameters 0 "none"
-    When I get the private key
-    And I sign the transaction with the private key
-    And I send the transaction
-
-  Scenario: Get pending transactions
-    Then I get pending transactions
-
-
-  Scenario: Suggested params
-    When I get the suggested params
-    And I get the suggested fee
-    Then the fee in the suggested params should equal the suggested fee
-
   Scenario: Version
     When I get versions with algod
-    Then v1 should be in the versions
-
-  Scenario: Account information
-    Given a kmd client
-    And wallet information
-    Then I get account information
+    Then v2 should be in the versions

--- a/features/integration/applications.feature
+++ b/features/integration/applications.feature
@@ -1,6 +1,5 @@
 Feature: Applications
    Background:
-      Given an algod client
       And a kmd client
       And wallet information
       And an algod v2 client connected to "localhost" port 60000 with token "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"

--- a/features/integration/applications.feature
+++ b/features/integration/applications.feature
@@ -1,6 +1,6 @@
 Feature: Applications
    Background:
-      And a kmd client
+      Given a kmd client
       And wallet information
       And an algod v2 client connected to "localhost" port 60000 with token "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
       And an indexer v2 client

--- a/features/integration/assets.feature
+++ b/features/integration/assets.feature
@@ -1,7 +1,7 @@
 @assets
 Feature: Assets
   Background:
-    Given an algod client
+    Given an algod v2 client connected to "localhost" port 60000 with token "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
     And a kmd client
     And wallet information
     And asset test fixture
@@ -10,7 +10,7 @@ Feature: Assets
     Given default asset creation transaction with total issuance <total>
     When I sign the transaction with kmd
     And I send the kmd-signed transaction
-    Then the transaction should go through
+    Then I wait for the transaction to be confirmed.
     When I update the asset index
     And I get the asset info
     Then the asset info should match the expected asset info
@@ -23,14 +23,14 @@ Feature: Assets
     Given default asset creation transaction with total issuance <total>
     When I sign the transaction with kmd
     And I send the kmd-signed transaction
-    Then the transaction should go through
+    Then I wait for the transaction to be confirmed.
     When I update the asset index
     And I get the asset info
     Then the asset info should match the expected asset info
     When I create a no-managers asset reconfigure transaction
     And I sign the transaction with kmd
     And I send the kmd-signed transaction
-    Then the transaction should go through
+    Then I wait for the transaction to be confirmed.
     When I get the asset info
     Then the asset info should match the expected asset info
 
@@ -42,13 +42,13 @@ Feature: Assets
     Given default asset creation transaction with total issuance <total>
     When I sign the transaction with kmd
     And I send the kmd-signed transaction
-    Then the transaction should go through
+    Then I wait for the transaction to be confirmed.
     When I update the asset index
     And I get the asset info
     And I create an asset destroy transaction
     And I sign the transaction with kmd
     And I send the kmd-signed transaction
-    Then the transaction should go through
+    Then I wait for the transaction to be confirmed.
     And I should be unable to get the asset info
 
     Examples:
@@ -59,16 +59,16 @@ Feature: Assets
     Given default asset creation transaction with total issuance <total>
     When I sign the transaction with kmd
     And I send the kmd-signed transaction
-    Then the transaction should go through
+    Then I wait for the transaction to be confirmed.
     When I update the asset index
     And I create a transaction for a second account, signalling asset acceptance
     And I sign the transaction with kmd
     And I send the kmd-signed transaction
-    Then the transaction should go through
+    Then I wait for the transaction to be confirmed.
     When I create a transaction transferring <amount> assets from creator to a second account
     And I sign the transaction with kmd
     And I send the kmd-signed transaction
-    Then the transaction should go through
+    Then I wait for the transaction to be confirmed.
     And the creator should have <expected balance> assets remaining
 
     Examples:
@@ -79,7 +79,7 @@ Feature: Assets
     Given default asset creation transaction with total issuance <total>
     When I sign the transaction with kmd
     And I send the kmd-signed transaction
-    Then the transaction should go through
+    Then I wait for the transaction to be confirmed.
     When I update the asset index
     When I create a transaction transferring <amount> assets from creator to a second account
     And I sign the transaction with kmd
@@ -95,21 +95,21 @@ Feature: Assets
     Given default asset creation transaction with total issuance <total>
     When I sign the transaction with kmd
     And I send the kmd-signed transaction
-    Then the transaction should go through
+    Then I wait for the transaction to be confirmed.
     When I update the asset index
     And I create a transaction for a second account, signalling asset acceptance
     And I sign the transaction with kmd
     And I send the kmd-signed transaction
-    Then the transaction should go through
+    Then I wait for the transaction to be confirmed.
     When I create a transaction transferring <amount> assets from creator to a second account
     And I sign the transaction with kmd
     And I send the kmd-signed transaction
-    Then the transaction should go through
+    Then I wait for the transaction to be confirmed.
     And the creator should have <expected balance> assets remaining
     When I create a freeze transaction targeting the second account
     And I sign the transaction with kmd
     And I send the kmd-signed transaction
-    Then the transaction should go through
+    Then I wait for the transaction to be confirmed.
     When I create a transaction transferring <amount> assets from creator to a second account
     And I sign the transaction with kmd
     And I send the bogus kmd-signed transaction
@@ -124,11 +124,11 @@ Feature: Assets
     When I create an un-freeze transaction targeting the second account
     And I sign the transaction with kmd
     And I send the kmd-signed transaction
-    Then the transaction should go through
+    Then I wait for the transaction to be confirmed.
     When I create a transaction transferring <amount> assets from a second account to creator
     And I sign the transaction with kmd
     And I send the kmd-signed transaction
-    Then the transaction should go through
+    Then I wait for the transaction to be confirmed.
     And the creator should have <final expected balance> assets remaining
 
     Examples:
@@ -139,12 +139,12 @@ Feature: Assets
     Given default-frozen asset creation transaction with total issuance <total>
     When I sign the transaction with kmd
     And I send the kmd-signed transaction
-    Then the transaction should go through
+    Then I wait for the transaction to be confirmed.
     When I update the asset index
     When I create a transaction for a second account, signalling asset acceptance
     And I sign the transaction with kmd
     And I send the kmd-signed transaction
-    Then the transaction should go through
+    Then I wait for the transaction to be confirmed.
     When I create a transaction transferring <amount> assets from creator to a second account
     And I send the bogus kmd-signed transaction
     Then the transaction should not go through
@@ -152,11 +152,11 @@ Feature: Assets
     When I create an un-freeze transaction targeting the second account
     And I sign the transaction with kmd
     And I send the kmd-signed transaction
-    Then the transaction should go through
+    Then I wait for the transaction to be confirmed.
     When I create a transaction transferring <amount> assets from creator to a second account
     And I sign the transaction with kmd
     And I send the kmd-signed transaction
-    Then the transaction should go through
+    Then I wait for the transaction to be confirmed.
     And the creator should have <final expected balance> assets remaining
 
     Examples:
@@ -167,20 +167,20 @@ Feature: Assets
     Given default asset creation transaction with total issuance <total>
     When I sign the transaction with kmd
     And I send the kmd-signed transaction
-    Then the transaction should go through
+    Then I wait for the transaction to be confirmed.
     When I update the asset index
     And I create a transaction for a second account, signalling asset acceptance
     And I sign the transaction with kmd
     And I send the kmd-signed transaction
-    Then the transaction should go through
+    Then I wait for the transaction to be confirmed.
     When I create a transaction transferring <amount> assets from creator to a second account
     And I sign the transaction with kmd
     And I send the kmd-signed transaction
-    Then the transaction should go through
+    Then I wait for the transaction to be confirmed.
     When I create a transaction revoking <amount> assets from a second account to creator
     And I sign the transaction with kmd
     And I send the kmd-signed transaction
-    Then the transaction should go through
+    Then I wait for the transaction to be confirmed.
     And the creator should have <expected balance> assets remaining
 
     Examples:

--- a/features/integration/kmd.feature
+++ b/features/integration/kmd.feature
@@ -29,7 +29,7 @@ Feature: KMD
     Then the key should not be in the wallet
 
   Scenario: Make account and get info
-    Given an algod client
+    Given an algod v2 client connected to "localhost" port 60000 with token "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
     When I generate a key using kmd
     Then I can get account information
 
@@ -39,7 +39,7 @@ Feature: KMD
     Then the private key should be equal to the exported private key
 
   Scenario Outline: Sign both ways
-    Given an algod client
+    Given an algod v2 client connected to "localhost" port 60000 with token "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
     And default transaction with parameters <amt> "<note>"
     When I get the private key
     And I sign the transaction with the private key
@@ -65,7 +65,7 @@ Feature: KMD
       | DN7MBMCL5JQ3PFUQS7TMX5AH4EEKOBJVDUF4TCV6WERATKFLQF4MQUPZTA BFRTECKTOOE7A5LHCF3TTEOH2A7BW46IYT2SX5VP6ANKEXHZYJY77SJTVM 47YPQTIGQEO7T4Y4RWDYWEKV6RTR2UNBQXBABEEGM72ESWDQNCQ52OPASU |
 
   Scenario Outline: Sign multisig both ways
-    Given an algod client
+    Given an algod v2 client connected to "localhost" port 60000 with token "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
     And default multisig transaction with parameters <amt> "<note>"
     When I sign the multisig transaction with kmd
     And I get the private key

--- a/features/integration/rekey.feature
+++ b/features/integration/rekey.feature
@@ -1,7 +1,7 @@
 @rekey_v1
 Feature: Sending transactions
   Background:
-    Given an algod client
+    Given an algod v2 client connected to "localhost" port 60000 with token "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
     And a kmd client
     And wallet information
 
@@ -12,19 +12,19 @@ Feature: Sending transactions
     And I add a rekeyTo field with address "<rekeyTo>"
     And I sign the transaction with the private key
     And I send the transaction
-    Then the transaction should go through
+    Then I wait for the transaction to be confirmed.
     Given default transaction with parameters <amt> "<note>" and rekeying key
     And mnemonic for private key "<mn>"
     And I sign the transaction with the private key
     And I send the transaction
-    Then the transaction should go through
+    Then I wait for the transaction to be confirmed.
     Given default transaction with parameters <amt> "<note>" and rekeying key
     When I get the private key
     And I add a rekeyTo field with the private key algorand address
     And mnemonic for private key "<mn>"
     And I sign the transaction with the private key
     And I send the transaction
-    Then the transaction should go through
+    Then I wait for the transaction to be confirmed.
 
     Examples:
       | amt | note         | rekeyTo                                                    | mn                                                                                                                                                               |

--- a/features/integration/send.feature
+++ b/features/integration/send.feature
@@ -1,6 +1,6 @@
 Feature: Sending transactions
   Background:
-    Given an algod client
+    Given an algod v2 client connected to "localhost" port 60000 with token "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
     And a kmd client
     And wallet information
 
@@ -10,7 +10,7 @@ Feature: Sending transactions
     When I get the private key
     And I sign the transaction with the private key
     And I send the transaction
-    Then the transaction should go through
+    Then I wait for the transaction to be confirmed.
 
     Examples:
       | amt     | note         |
@@ -36,7 +36,7 @@ Feature: Sending transactions
     When I get the private key
     And I sign the transaction with the private key
     And I send the transaction
-    Then the transaction should go through
+    Then I wait for the transaction to be confirmed.
 
     Examples:
       | type             |

--- a/features/resources/v2algodclient_responsejsons/sourcemap.json
+++ b/features/resources/v2algodclient_responsejsons/sourcemap.json
@@ -1,1 +1,7 @@
-{"version":3,"sources":[],"names":[],"mapping":";AAOA;;;;;;;;;;;;;;;;;;;;;;;;;;;;AACA;AACA;;;AACA;;;AACA;AACA;;AACA;AACA;;;AACA;AACA;AACA;;AACA;;AACA;AACA;AACA","mappings":";AAOA;;;;;;;;;;;;;;;;;;;;;;;;;;;;AACA;AACA;;;AACA;;;AACA;AACA;;AACA;AACA;;;AACA;AACA;AACA;;AACA;;AACA;AACA;AACA"}
+{
+  "version": 3,
+  "sources": [],
+  "names": [],
+  "mapping": ";AAOA;;;;;;;;;;;;;;;;;;;;;;;;;;;;AACA;AACA;;;AACA;;;AACA;AACA;;AACA;AACA;;;AACA;AACA;AACA;;AACA;;AACA;AACA;AACA",
+  "mappings": ";AAOA;;;;;;;;;;;;;;;;;;;;;;;;;;;;AACA;AACA;;;AACA;;;AACA;AACA;;AACA;AACA;;;AACA;AACA;AACA;;AACA;;AACA;AACA;AACA"
+}

--- a/features/resources/v2algodclient_responsejsons/sourcemap.json
+++ b/features/resources/v2algodclient_responsejsons/sourcemap.json
@@ -1,7 +1,1 @@
-{
-  "version": 3,
-  "sources": [],
-  "names": [],
-  "mapping": ";AAOA;;;;;;;;;;;;;;;;;;;;;;;;;;;;AACA;AACA;;;AACA;;;AACA;AACA;;AACA;AACA;;;AACA;AACA;AACA;;AACA;;AACA;AACA;AACA",
-  "mappings": ";AAOA;;;;;;;;;;;;;;;;;;;;;;;;;;;;AACA;AACA;;;AACA;;;AACA;AACA;;AACA;AACA;;;AACA;AACA;AACA;;AACA;;AACA;AACA;AACA"
-}
+{"version":3,"sources":[],"names":[],"mapping":";AAOA;;;;;;;;;;;;;;;;;;;;;;;;;;;;AACA;AACA;;;AACA;;;AACA;AACA;;AACA;AACA;;;AACA;AACA;AACA;;AACA;;AACA;AACA;AACA","mappings":";AAOA;;;;;;;;;;;;;;;;;;;;;;;;;;;;AACA;AACA;;;AACA;;;AACA;AACA;;AACA;AACA;;;AACA;AACA;AACA;;AACA;;AACA;AACA;AACA"}

--- a/utils/unused_steps_analysis.ipynb
+++ b/utils/unused_steps_analysis.ipynb
@@ -618,11 +618,11 @@
     "    matches = cuke_df[cuke_df.filled_step.str.match(step_re)]\n",
     "    return None if matches.empty else matches.iloc[0].filled_step\n",
     "\n",
-    "jss = jssdk_rex_df.iloc[2]\n",
-    "jsm = match_stepre2cucumber(jss.step, filled_steps)\n",
+    "# jss = jssdk_rex_df.iloc[2]\n",
+    "# jsm = match_stepre2cucumber(jss.step, filled_steps)\n",
     "\n",
-    "print(f\"\"\"{jss=}\n",
-    "{jsm=}\"\"\")"
+    "# print(f\"\"\"{jss=}\n",
+    "# {jsm=}\"\"\")"
    ]
   },
   {
@@ -816,7 +816,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# py_remaninder.to_clipboard()"
+    "# py_remainder.to_clipboard()"
    ]
   },
   {


### PR DESCRIPTION
This PR makes changes to the cucumber steps so that v1 algod tests are removed and some v1 steps are changed to use v2 implementations.

Changes:
* `algod.feature`: Only retains version agnostic endpoint tests (`/versions` and `/health`). The rest should be covered by `v2algodclient_paths.feature` tests.
* Change the v1 txn waiting step `the transaction should go through` to the v2 waitForTransaction step `I wait for the transaction to be confirmed.`


| SDK Link  | Link |
|--------|------|
| Go     |  https://github.com/algorand/go-algorand-sdk/pull/434    |
| Java   |  https://github.com/algorand/java-algorand-sdk/pull/425    |
| Python | https://github.com/algorand/py-algorand-sdk/pull/400     |
| JS     |   https://github.com/algorand/js-algorand-sdk/pull/693   |

Closes #247 