### PR TITLE
Try to use previous sandbox commit for dev mode

### DIFF
--- a/.env
+++ b/.env
@@ -22,7 +22,7 @@ INDEXER_SHA=""
 
 # Sandbox configuration:
 SANDBOX_URL="https://github.com/algorand/sandbox"
-SANDBOX_BRANCH="master"
+SANDBOX_BRANCH="last_working"
 LOCAL_SANDBOX_DIR=".sandbox"
 
 # replacement values for Sandbox's docker-compose:


### PR DESCRIPTION
The latest sandbox commit has trouble bringing up indexer dev mode, which means the indexer sdk tests will fail. This PR temporarily points sandbox to a branch with the previous commit.

CI seems to pass when PRs are pointed to this branch (`revert-sandbox`): https://app.circleci.com/pipelines/github/algorand/go-algorand-sdk/657/workflows/9fb1f7c6-3c1c-49e5-9a09-a50024055395/jobs/2007
PR change for branch: https://github.com/algorand/go-algorand-sdk/pull/447/files#diff-f0793f352c661a02f7a89203f5a5c5c414f77076ac49b8219faf84f51c959f1bR3

Sandbox issue here:
https://github.com/algorand/sandbox/issues/161