### PR TITLE
Revert sandbox branch back to master

### DIFF
--- a/.env
+++ b/.env
@@ -22,7 +22,7 @@ INDEXER_SHA=""
 
 # Sandbox configuration:
 SANDBOX_URL="https://github.com/algorand/sandbox"
-SANDBOX_BRANCH="last_working"
+SANDBOX_BRANCH="master"
 LOCAL_SANDBOX_DIR=".sandbox"
 
 # replacement values for Sandbox's docker-compose:


### PR DESCRIPTION
This PR reverts the sandbox branch for SDK tests back to master. This PR in sandbox fixed indexer on dev mode: https://github.com/algorand/sandbox/pull/162

CI Test run here that passes: https://app.circleci.com/pipelines/github/algorand/go-algorand-sdk/676/workflows/ff524118-f3b9-424d-9038-875fe6474eb8/jobs/2027
Commit points to this branch: https://github.com/algorand/go-algorand-sdk/pull/451/commits/0e0ef73e43e253c72532c7f292482c618282fb95