### PR TITLE
Simulate endpoint tests

### DIFF
--- a/.env
+++ b/.env
@@ -2,14 +2,14 @@
 VERBOSE_HARNESS=0
 
 # Used to determine sandbox build type:
-TYPE="channel" # OR "source"
+TYPE="source" # OR "source"
 
 # Used when TYPE==channel:
 ALGOD_CHANNEL="nightly"
 
 # Used when TYPE==source:
-ALGOD_URL="https://github.com/algorand/go-algorand"
-ALGOD_BRANCH="master"
+ALGOD_URL="https://github.com/jasonpaulos/go-algorand"
+ALGOD_BRANCH="nonexperimental-simulation"
 ALGOD_SHA=""
 
 # Used regardless of TYPE:

--- a/.env
+++ b/.env
@@ -2,7 +2,7 @@
 VERBOSE_HARNESS=0
 
 # Used to determine sandbox build type:
-TYPE="channel" # OR "source"
+TYPE="source" # OR "source"
 
 # Used when TYPE==channel:
 ALGOD_CHANNEL="nightly"

--- a/.env
+++ b/.env
@@ -22,7 +22,7 @@ INDEXER_SHA=""
 
 # Sandbox configuration:
 SANDBOX_URL="https://github.com/algorand/sandbox"
-SANDBOX_BRANCH="master"
+SANDBOX_BRANCH="experimental-api"
 LOCAL_SANDBOX_DIR=".sandbox"
 
 # replacement values for Sandbox's docker-compose:

--- a/.env
+++ b/.env
@@ -2,7 +2,7 @@
 VERBOSE_HARNESS=0
 
 # Used to determine sandbox build type:
-TYPE="source" # OR "source"
+TYPE="channel" # OR "source"
 
 # Used when TYPE==channel:
 ALGOD_CHANNEL="nightly"
@@ -17,7 +17,7 @@ NETWORK_TEMPLATE="images/algod/DevModeNetwork.json"  # refers to the ./images di
 NETWORK_NUM_ROUNDS=30000
 INDEXER_URL="https://github.com/algorand/indexer"
 NODE_ARCHIVAL="False"
-INDEXER_BRANCH="develop"
+INDEXER_BRANCH="master"
 INDEXER_SHA=""
 
 # Sandbox configuration:

--- a/.env
+++ b/.env
@@ -2,14 +2,14 @@
 VERBOSE_HARNESS=0
 
 # Used to determine sandbox build type:
-TYPE="source" # OR "source"
+TYPE="channel" # OR "source"
 
 # Used when TYPE==channel:
 ALGOD_CHANNEL="nightly"
 
 # Used when TYPE==source:
-ALGOD_URL="https://github.com/jasonpaulos/go-algorand"
-ALGOD_BRANCH="nonexperimental-simulation"
+ALGOD_URL="https://github.com/algorand/go-algorand"
+ALGOD_BRANCH="master"
 ALGOD_SHA=""
 
 # Used regardless of TYPE:
@@ -22,7 +22,7 @@ INDEXER_SHA=""
 
 # Sandbox configuration:
 SANDBOX_URL="https://github.com/algorand/sandbox"
-SANDBOX_BRANCH="experimental-api"
+SANDBOX_BRANCH="master"
 LOCAL_SANDBOX_DIR=".sandbox"
 
 # replacement values for Sandbox's docker-compose:

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ These reside in the [integration features directory](features/integration)
 | @kmd                   | Test the kmd REST endpoints.                                                           |
 | @rekey_v1              | Test the rekeying transactions.                                                        |
 | @send                  | Test the ability to submit transactions to algod.                                      |
+| @simulate              | Test the ability to simulate transactions with algod.                                  |
 
 ### Test Implementation Status
 

--- a/features/integration/abi.feature
+++ b/features/integration/abi.feature
@@ -5,7 +5,7 @@ Feature: ABI Interaction
     And a kmd client
     And wallet information
     And suggested transaction parameters from the algod v2 client
-    And I create a new transient account and fund it with 100000000 microalgos.
+    And I create a new transient account and fund it with 10000000 microalgos.
     And I make a transaction signer for the transient account.
     And I build an application transaction with the transient account, the current application, suggested params, operation "create", approval-program "programs/abi_method_call.teal.tok", clear-program "programs/one.teal.tok", global-bytes 0, global-ints 0, local-bytes 1, local-ints 0, app-args "", foreign-apps "", foreign-assets "", app-accounts "", extra-pages 0, boxes ""
     And I sign and submit the transaction, saving the txid. If there is an error it is "".
@@ -98,7 +98,7 @@ Feature: ABI Interaction
     And The app should have returned "ABRnb29kYnllIEFsZ29yYW5kIEZhbg==".
 
   Scenario: Method call delete execution
-    Given I create a new transient account and fund it with 100000000 microalgos.
+    Given I create a new transient account and fund it with 10000000 microalgos.
     And I make a transaction signer for the transient account.
     And I build an application transaction with the transient account, the current application, suggested params, operation "create", approval-program "programs/abi_method_call.teal.tok", clear-program "programs/one.teal.tok", global-bytes 0, global-ints 0, local-bytes 1, local-ints 0, app-args "", foreign-apps "", foreign-assets "", app-accounts "", extra-pages 0, boxes ""
     And I sign and submit the transaction, saving the txid. If there is an error it is "".

--- a/features/integration/c2c.feature
+++ b/features/integration/c2c.feature
@@ -5,7 +5,7 @@ Feature: Contract to Contract Interaction
     * a kmd client
     * wallet information
     * suggested transaction parameters from the algod v2 client
-    * I create a new transient account and fund it with 100000000 microalgos.
+    * I create a new transient account and fund it with 10000000 microalgos.
     * I make a transaction signer for the transient account.
     * I reset the array of application IDs to remember.
 
@@ -47,7 +47,7 @@ Feature: Contract to Contract Interaction
     And I wait for the transaction to be confirmed.
     Given I remember the new application ID.
     # Need to fund RandomByte because it pays for calling RandomInteger:
-    And I fund the current application's address with 100000000 microalgos.
+    And I fund the current application's address with 10000000 microalgos.
 
     Given a new AtomicTransactionComposer
 
@@ -85,7 +85,7 @@ Feature: Contract to Contract Interaction
     And I wait for the transaction to be confirmed.
     Given I remember the new application ID.
     # Need to fund SlotMachine because it pays for calling RandomByte:
-    And I fund the current application's address with 100000000 microalgos.
+    And I fund the current application's address with 10000000 microalgos.
 
     Given a new AtomicTransactionComposer
 

--- a/features/integration/simulate.feature
+++ b/features/integration/simulate.feature
@@ -1,6 +1,6 @@
 Feature: Simulating transactions
   Background:
-    Given an algod v2 client connected to "localhost" port 4001 with token "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    Given an algod v2 client
     And a kmd client
     And wallet information
     And suggested transaction parameters from the algod v2 client

--- a/features/integration/simulate.feature
+++ b/features/integration/simulate.feature
@@ -21,18 +21,29 @@ Feature: Simulating transactions
       | 1234523 | X4Bl4wQ9rCo= |
 
   @simulate
+  Scenario: Simulating unsigned payment transaction
+    Given default transaction with parameters 100001 "X4Bl4wQ9rCo="
+    When I prepare the transaction without signatures for simulation
+    And I simulate the transaction
+    Then the simulation should report missing signatures at group "0", transactions "0"
+
+  @simulate
   Scenario: Simulating duplicate transactions in a group and overspending errors
     Given a new AtomicTransactionComposer
     When I build a payment transaction with sender "transient", receiver "transient", amount 100001, close remainder to ""
     And I create a transaction with signer with the current transaction.
     And I add the current transaction with signer to the composer.
-    Then I simulate the current transaction group with the composer
+    Then I build the transaction group with the composer. If there is an error it is "".
+    And I gather signatures with the composer.
+    And I simulate the current transaction group with the composer
     And the simulation should succeed without any failure message
 
     # Check for duplicate transaction errors
     And I clone the composer.
     When I add the current transaction with signer to the composer.
-    Then I simulate the current transaction group with the composer
+    Then I build the transaction group with the composer. If there is an error it is "".
+    And I gather signatures with the composer.
+    And I simulate the current transaction group with the composer
     And the simulation should report a failure at group "0", path "1" with message "transaction already in ledger"
 
     # Check for overspending errors
@@ -43,7 +54,24 @@ Feature: Simulating transactions
     Then I simulate the current transaction group with the composer
     And the simulation should report a failure at group "0", path "0" with message "overspend"
 
-  # @simulate
+  @simulate
+  Scenario: Simulating unsigned transactions in the ATC group
+    Given a new AtomicTransactionComposer
+    When I build a payment transaction with sender "transient", receiver "transient", amount 100001, close remainder to ""
+    And I create a transaction with an empty signer with the current transaction.
+    And I add the current transaction with signer to the composer.
+    Then I simulate the current transaction group with the composer
+    And the simulation should report missing signatures at group "0", transactions "0"
+    
+    # Add another unsigned transaction
+    And I clone the composer.
+    When I build a payment transaction with sender "transient", receiver "transient", amount 100002, close remainder to ""
+    And I create a transaction with an empty signer with the current transaction.
+    And I add the current transaction with signer to the composer.
+    Then I simulate the current transaction group with the composer
+    And the simulation should report missing signatures at group "0", transactions "0,1"
+
+  @simulate
   Scenario: Simulating bad inner transactions in the ATC
     Given a new AtomicTransactionComposer
     # Create an app at context index 0: FakeRandom

--- a/features/integration/simulate.feature
+++ b/features/integration/simulate.feature
@@ -4,7 +4,7 @@ Feature: Simulating transactions
     And a kmd client
     And wallet information
     And suggested transaction parameters from the algod v2 client
-    And I create a new transient account and fund it with 100000000 microalgos.
+    And I create a new transient account and fund it with 10000000 microalgos.
     And I make a transaction signer for the transient account.
 
   @simulate
@@ -42,7 +42,7 @@ Feature: Simulating transactions
     And I wait for the transaction to be confirmed.
     Given I remember the new application ID.
     
-    # Create another app at index 1: RandomByte
+    # Create another app at context index 1: RandomByte
     When I build an application transaction with the transient account, the current application, suggested params, operation "create", approval-program "programs/random_byte.teal", clear-program "programs/six.teal", global-bytes 0, global-ints 0, local-bytes 0, local-ints 0, app-args "", foreign-apps "", foreign-assets "", app-accounts "", extra-pages 0, boxes ""
     And I sign and submit the transaction, saving the txid. If there is an error it is "".
     And I wait for the transaction to be confirmed.

--- a/features/integration/simulate.feature
+++ b/features/integration/simulate.feature
@@ -1,0 +1,34 @@
+Feature: Simulating transactions
+  Background:
+    Given an algod v2 client connected to "localhost" port 4001 with token "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    And a kmd client
+    And wallet information
+    And suggested transaction parameters from the algod v2 client
+
+  @simulate
+  Scenario Outline: Simulating successful payment transactions
+    Given default transaction with parameters <amt> "<note>"
+    When I get the private key
+    And I sign the transaction with the private key
+    And I simulate the transaction
+    Then the simulation should succeed
+
+    Examples:
+      | amt     | note         |
+      | 0       | X4Bl4wQ9rCo= |
+      | 1234523 | X4Bl4wQ9rCo= |
+
+  @simulate
+  Scenario: Simulating duplicate transactions in a group
+    Given a new AtomicTransactionComposer
+    And I create a new transient account and fund it with 100000000 microalgos.
+    When I build a payment transaction with sender "transient", receiver "transient", amount 100001, close remainder to ""
+    And I make a transaction signer for the transient account.
+    And I create a transaction with signer with the current transaction.
+    And I add the current transaction with signer to the composer.
+    Then I simulate the current transaction group with the composer
+    And the simulation should succeed
+    And I clone the composer.
+    When I add the current transaction with signer to the composer.
+    Then I simulate the current transaction group with the composer
+    And the simulation should fail at path "1" with message "transaction already in ledger"

--- a/features/integration/simulate.feature
+++ b/features/integration/simulate.feature
@@ -33,7 +33,7 @@ Feature: Simulating transactions
     And I clone the composer.
     When I add the current transaction with signer to the composer.
     Then I simulate the current transaction group with the composer
-    And the simulation should report a failure at path "1" with message "transaction already in ledger"
+    And the simulation should report a failure at group "0", path "1" with message "transaction already in ledger"
 
     # Check for overspending errors
     Given a new AtomicTransactionComposer
@@ -41,7 +41,7 @@ Feature: Simulating transactions
     And I create a transaction with signer with the current transaction.
     And I add the current transaction with signer to the composer.
     Then I simulate the current transaction group with the composer
-    And the simulation should report a failure at path "0" with message "overspend"
+    And the simulation should report a failure at group "0", path "0" with message "overspend"
 
   # @simulate
   Scenario: Simulating bad inner transactions in the ATC
@@ -91,4 +91,4 @@ Feature: Simulating transactions
 
     # The simulation should fail at the third transaction's first inner transaction (2,0) due to no app args being passed into the app.
     Then I simulate the current transaction group with the composer
-    And the simulation should report a failure at path "2,0" with message "invalid ApplicationArgs"
+    And the simulation should report a failure at group "0", path "2,0" with message "invalid ApplicationArgs"

--- a/features/integration/simulate.feature
+++ b/features/integration/simulate.feature
@@ -21,7 +21,7 @@ Feature: Simulating transactions
   @simulate
   Scenario: Simulating duplicate transactions in a group
     Given a new AtomicTransactionComposer
-    And I create a new transient account and fund it with 100000000 microalgos.
+    And I create a new transient account and fund it with 10000000 microalgos.
     When I build a payment transaction with sender "transient", receiver "transient", amount 100001, close remainder to ""
     And I make a transaction signer for the transient account.
     And I create a transaction with signer with the current transaction.

--- a/features/integration/simulate.feature
+++ b/features/integration/simulate.feature
@@ -13,7 +13,7 @@ Feature: Simulating transactions
     When I get the private key
     And I sign the transaction with the private key
     And I simulate the transaction
-    Then the simulation should succeed
+    Then the simulation should succeed without any failure message
 
     Examples:
       | amt     | note         |
@@ -27,11 +27,11 @@ Feature: Simulating transactions
     And I create a transaction with signer with the current transaction.
     And I add the current transaction with signer to the composer.
     Then I simulate the current transaction group with the composer
-    And the simulation should succeed
+    And the simulation should succeed without any failure message
     And I clone the composer.
     When I add the current transaction with signer to the composer.
     Then I simulate the current transaction group with the composer
-    And the simulation should fail at path "1" with message "transaction already in ledger"
+    And the simulation should report a failure at path "1" with message "transaction already in ledger"
 
   @simulate
   Scenario: Simulating bad inner transactions in the ATC
@@ -81,4 +81,4 @@ Feature: Simulating transactions
 
     # The simulation should fail at the third transaction's first inner transaction (2,0) due to no app args being passed into the app.
     Then I simulate the current transaction group with the composer
-    And the simulation should fail at path "2,0" with message "invalid ApplicationArgs"
+    And the simulation should report a failure at path "2,0" with message "invalid ApplicationArgs"

--- a/features/resources/programs/random_byte.teal
+++ b/features/resources/programs/random_byte.teal
@@ -13,9 +13,14 @@ txn ApplicationID
 bz finish  // creating ok
 
 txn ApplicationArgs 0
+method "badMethod(string,application)void"
+==
+bnz err_program // Call FakeRandom app in inner txn with bad app args (should error)
+
+txn ApplicationArgs 0
 method "randElement(string,application)(byte,byte[17])"
 ==
-assert      // other than create, only the app call is allowed
+assert      // other than create, only badMethod and randElement method call is allowed
 
 itxn_begin
     int appl
@@ -88,3 +93,14 @@ log
 finish:
     int 1
     return
+
+err_program:
+    itxn_begin
+        int appl
+        itxn_field TypeEnum
+
+        txn Applications 1 // FakeRandom
+        itxn_field ApplicationID
+    itxn_submit
+
+    b finish


### PR DESCRIPTION
Adds tests for:
* Calling the simulate endpoint for basic payment txns
* Using the simulate method/functionality within an AtomicTransactionComposer
* Check fail-path for inner transaction failures
* Simulating unsigned transactions 

Also changes the following (not-necessarily related to simulate)
* Decrease transient account funding to reduce economic burden on genesis accounts
* Add a method in `RandomByte` TEAL contract to call a bad inner txn

Closes #270 

Related SDK PRs
* https://github.com/algorand/py-algorand-sdk/pull/420
* https://github.com/algorand/js-algorand-sdk/pull/743
