### PR TITLE
SANDBOX_CLEAN_CACHE with Default On

### DIFF
--- a/.env
+++ b/.env
@@ -23,7 +23,7 @@ INDEXER_SHA=""
 # Sandbox configuration:
 SANDBOX_URL="https://github.com/algorand/sandbox"
 SANDBOX_BRANCH="master"
-SANDBOX_FORCE_RECREATE=1
+SANDBOX_CLEAN_CACHE=1
 LOCAL_SANDBOX_DIR=".sandbox"
 
 # replacement values for Sandbox's docker-compose:

--- a/.env
+++ b/.env
@@ -23,6 +23,7 @@ INDEXER_SHA=""
 # Sandbox configuration:
 SANDBOX_URL="https://github.com/algorand/sandbox"
 SANDBOX_BRANCH="master"
+SANDBOX_FORCE_RECREATE=1
 LOCAL_SANDBOX_DIR=".sandbox"
 
 # replacement values for Sandbox's docker-compose:

--- a/scripts/up.sh
+++ b/scripts/up.sh
@@ -67,6 +67,8 @@ pushd "$LOCAL_SANDBOX_DIR"
 
 [[ "$VERBOSE_HARNESS" = 1 ]] && V_FLAG="-v" || V_FLAG=""
 
-echo "$THIS: running sandbox with command [./sandbox up harness $V_FLAG]"
-./sandbox up harness "$V_FLAG"
+[[ "$SANDBOX_FORCE_RECREATE" = 1 ]] && F_FLAG="-f" || F_FLAG=""
+
+echo "$THIS: running sandbox with command [./sandbox up harness $V_FLAG $F_FLAG]"
+./sandbox up harness "$V_FLAG" "$F_FLAG"
 echo "$THIS: seconds it took to finish getting sandbox harness ($(pwd)) up and running: $(($(date "+%s") - START))s"

--- a/scripts/up.sh
+++ b/scripts/up.sh
@@ -22,6 +22,7 @@ while (( "$#" )); do
   shift
 done
 echo "$THIS: VERBOSE_HARNESS=$VERBOSE_HARNESS"
+echo "$THIS: SANDBOX_CLEAN_CACHE=$SANDBOX_CLEAN_CACHE"
 
 if [[ $TYPE == "channel" ]] || [[ $TYPE == "source" ]]; then
   echo "$THIS: setting sandbox variables for git based on TYPE=$TYPE."
@@ -67,8 +68,9 @@ pushd "$LOCAL_SANDBOX_DIR"
 
 [[ "$VERBOSE_HARNESS" = 1 ]] && V_FLAG="-v" || V_FLAG=""
 
-[[ "$SANDBOX_FORCE_RECREATE" = 1 ]] && F_FLAG="-f" || F_FLAG=""
 
-echo "$THIS: running sandbox with command [./sandbox up harness $V_FLAG $F_FLAG]"
-./sandbox up harness "$V_FLAG" "$F_FLAG"
+[[ "$SANDBOX_CLEAN_CACHE" = 0 ]] || touch .clean
+
+echo "$THIS: running sandbox with command [./sandbox up harness $V_FLAG]"
+./sandbox up harness "$V_FLAG"
 echo "$THIS: seconds it took to finish getting sandbox harness ($(pwd)) up and running: $(($(date "+%s") - START))s"


### PR DESCRIPTION
Sometimes my local tests status mismatch what happens in C.I. One common culprit is Docker's layer caching. For example, recently, an indexer layer was being cached from December 2022. While tests were failing in C.I. they were passing on my machine.

This PR should fix this mismatch

This shouldn't impact C.I., as no layer caching should be taking place.

## What if I still want to cache sandbox layers?

You can turn layer caching back on by setting `SANDBOX_CLEAN_CACHE=0` in `.env`