### PR TITLE
Pin Indexer to master until follower node issue is resolved

### DIFF
--- a/.env
+++ b/.env
@@ -17,7 +17,7 @@ NETWORK_TEMPLATE="images/algod/DevModeNetwork.json"  # refers to the ./images di
 NETWORK_NUM_ROUNDS=30000
 INDEXER_URL="https://github.com/algorand/indexer"
 NODE_ARCHIVAL="False"
-INDEXER_BRANCH="develop"
+INDEXER_BRANCH="master"
 INDEXER_SHA=""
 
 # Sandbox configuration:


### PR DESCRIPTION
# Summary
Currently, the bleeding edge of indexer is broken in sandbox because sandbox doesn't properly set up the follower node. (see: https://github.com/algorand/sandbox/issues/175). In order to get test passing in the SDK's, I recommend this patch. Once sandbox is fixed, we should revert to its `develop` branch.

## Testing
* Before the fix, it [was failing](https://app.circleci.com/pipelines/github/algorand/py-algorand-sdk/1284/workflows/7c8ee195-5ca1-444a-b2c1-bdbf4f6e3a77/jobs/6925?invite=true#step-102-586)
* After the fix, it's [passing](https://app.circleci.com/pipelines/github/algorand/py-algorand-sdk/1295/workflows/ac198c0f-4d60-4a45-a1eb-29ae5b537061/jobs/7051)