### PR TITLE
Add a step to simulate an unsigned txn and an overspending error

### DIFF
--- a/features/integration/simulate.feature
+++ b/features/integration/simulate.feature
@@ -71,6 +71,17 @@ Feature: Simulating transactions
     Then I simulate the current transaction group with the composer
     And the simulation should report missing signatures at group "0", transactions "0,1"
 
+    # Check for an overspending error in addition to the unsigned transaction
+    # Add another unsigned transaction
+    And I clone the composer.
+    When I build a payment transaction with sender "transient", receiver "transient", amount 999999999, close remainder to ""
+    And I create a transaction with an empty signer with the current transaction.
+    And I add the current transaction with signer to the composer.
+    And I gather signatures with the composer.
+    Then I simulate the current transaction group with the composer
+    And the simulation should report missing signatures at group "0", transactions "0,1,2"
+    And the simulation should report a failure at group "0", path "2" with message "overspend"
+
   @simulate
   Scenario: Simulating bad inner transactions in the ATC
     Given a new AtomicTransactionComposer

--- a/features/integration/simulate.feature
+++ b/features/integration/simulate.feature
@@ -77,7 +77,6 @@ Feature: Simulating transactions
     When I build a payment transaction with sender "transient", receiver "transient", amount 999999999, close remainder to ""
     And I create a transaction with an empty signer with the current transaction.
     And I add the current transaction with signer to the composer.
-    And I gather signatures with the composer.
     Then I simulate the current transaction group with the composer
     And the simulation should report missing signatures at group "0", transactions "0,1,2"
     And the simulation should report a failure at group "0", path "2" with message "overspend"


### PR DESCRIPTION
Implemented in: https://github.com/algorand/js-algorand-sdk/pull/743 ([a5975ac](https://github.com/algorand/js-algorand-sdk/pull/743/commits/a5975acb2940ee2d643bdf9dd804692d6a141f92)). Manually verified in Python SDK that everything works as expected.