### PR TITLE
client: Add unit.client-no-headers tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ These reside in the [unit features directory](features/unit)
 | @unit.applications.boxes             | Box endpoints for Algod and Indexer.                                                                        |
 | @unit.atomic_transaction_composer    | ABI / atomic transaction construction unit tests.                                                           |
 | @unit.atc_method_args                | Test that algod's Atomic Transaction Composer assserts that the same number of arguments given as expected. |
+| @unit.client-no-headers              | Tests that clients don't add non-standard http headers when no (or an empty) auth token is provided.        |
 | @unit.dryrun                         | Dryrun endpoint added to Algod.                                                                             |
 | @unit.dryrun.trace.application       | DryrunResult formatting tests.                                                                              |
 | @unit.feetest                        | Fee transaction encoding tests.                                                                             |

--- a/README.md
+++ b/README.md
@@ -86,9 +86,10 @@ These reside in the [integration features directory](features/integration)
 However, a few are not fully supported:
 
 | tag                             | SDK's which implement        |
-| ------------------------------- | ---------------------------- |
+| ------------------------------- |------------------------------|
 | @dryrun.testing                 | Python only                  |
 | @unit.c2c                       | missing from Python          |
+| @unit.client-no-headers         | JS only                      |
 | @unit.indexer.rekey             | missing from Python and JS   |
 | @unit.responses.genesis         | missing from Python and Java |
 | @unit.responses.messagepack     | missing from Python          |

--- a/features/unit/client-no-headers.feature
+++ b/features/unit/client-no-headers.feature
@@ -1,0 +1,31 @@
+@unit.client-no-headers
+Feature: Client No Headers
+  Background:
+    # The mock servers are
+    Given mock server recording request paths
+    And an algod v2 client connected to mock server with token ""
+    And an indexer v2 client connected to mock server with token ""
+
+    # Using a random API call since we're just testing the headers and don't care about the request
+  Scenario: Auth Headers Algod
+    Given expected headers
+      | key             |
+      | accept-encoding |
+      | user-agent      |
+      | accept          |
+      | connection      |
+      | host            |
+    When we make an arbitrary algod call
+    Then expect the observed header keys to equal the expected header keys
+
+    # Using a random API call since we're just testing the headers and don't care about the request
+  Scenario: Auth Headers Indexer
+    Given expected headers
+      | key             |
+      | accept-encoding |
+      | user-agent      |
+      | accept          |
+      | connection      |
+      | host            |
+    When we make an arbitrary indexer call
+    Then expect the observed header keys to equal the expected header keys


### PR DESCRIPTION
Adds tests which assert the headers being sent in requests when no auth token is given.

These are implemented for the JS SDK in https://github.com/algorand/js-algorand-sdk/pull/782