### PR TITLE
ENV: Update indexer from hotfix branch to master

### DIFF
--- a/.env
+++ b/.env
@@ -17,7 +17,7 @@ NETWORK_TEMPLATE="images/algod/DevModeNetwork.json"  # refers to the ./images di
 NETWORK_NUM_ROUNDS=30000
 INDEXER_URL="https://github.com/algorand/indexer"
 NODE_ARCHIVAL="False"
-INDEXER_BRANCH="hotfix/2.15.4"
+INDEXER_BRANCH="master"
 INDEXER_SHA=""
 
 # Sandbox configuration:


### PR DESCRIPTION
## Summary
Updates INDEXER_BRANCH to "master"
Integration tests were failing on sandbox spin up since INDEXER_BRANCH="hotfix/2.15.4" has been merged and removed. 