### PR TITLE
Update Indexer branch to develop.

### DIFF
--- a/.env
+++ b/.env
@@ -17,7 +17,7 @@ NETWORK_TEMPLATE="images/algod/DevModeNetwork.json"  # refers to the ./images di
 NETWORK_NUM_ROUNDS=30000
 INDEXER_URL="https://github.com/algorand/indexer"
 NODE_ARCHIVAL="False"
-INDEXER_BRANCH="master"
+INDEXER_BRANCH="develop" # sandbox no longer supports the pre-refactor code currently in master.
 INDEXER_SHA=""
 
 # Sandbox configuration:


### PR DESCRIPTION
Sandbox no longer supports the pre-license refactoring code in master so we need to change the default branch to develop.