### PR TITLE
tests: Add json deltas, update sleep time

### DIFF
--- a/features/integration/applications.feature
+++ b/features/integration/applications.feature
@@ -177,14 +177,14 @@ Feature: Applications
       And I sign and submit the transaction, saving the txid. If there is an error it is "".
       And I wait for the transaction to be confirmed.
       Then according to "algod", the contents of the box with name "str:foo bar" in the current application should be "YmF6IHF1eAAAAAAAAAAAAAAAAAAAAAAA". If there is an error it is "".
-      And I sleep for 500 milliseconds for indexer to digest things down.
+      And I sleep for 1000 milliseconds for indexer to digest things down.
       And according to "indexer", the contents of the box with name "str:foo bar" in the current application should be "YmF6IHF1eAAAAAAAAAAAAAAAAAAAAAAA". If there is an error it is "".
 
       # full check confirmed by both algod and indexer
       Then according to "algod", the current application should have the following boxes "Zm9vIGJhcg==:APj/IA==:bmFtZQ==:MTE0NTE0".
       And according to "algod", with 6 being the parameter that limits results, the current application should have 4 boxes.
 
-      And I sleep for 500 milliseconds for indexer to digest things down.
+      And I sleep for 1000 milliseconds for indexer to digest things down.
       And according to "indexer", the current application should have the following boxes "Zm9vIGJhcg==:APj/IA==:bmFtZQ==:MTE0NTE0".
       And according to "indexer", with 2 being the parameter that limits results, the current application should have 2 boxes.
       And according to "indexer", with 6 being the parameter that limits results, the current application should have 4 boxes.
@@ -196,7 +196,7 @@ Feature: Applications
       And according to "algod", the current application should have the following boxes "Zm9vIGJhcg==:APj/IA==:MTE0NTE0".
 
       # move to indexer testing steps
-      And I sleep for 500 milliseconds for indexer to digest things down.
+      And I sleep for 1000 milliseconds for indexer to digest things down.
       And according to "indexer", the contents of the box with name "str:name" in the current application should be "". If there is an error it is "no application boxes found".
       And according to "indexer", the contents of the box with name "b64:APj/IA==" in the current application should be "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA". If there is an error it is "".
       And according to "indexer", the current application should have the following boxes "Zm9vIGJhcg==:APj/IA==:MTE0NTE0".

--- a/features/resources/v2algodclient_responsejsons/statedelta_betanet_22085518.json
+++ b/features/resources/v2algodclient_responsejsons/statedelta_betanet_22085518.json
@@ -1,0 +1,1626 @@
+{
+  "Accts": {
+    "Accts": [
+      {
+        "Addr": "7777777777777777777777777777777777777777777777777774MSJUVU",
+        "AuthAddr": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ",
+        "MicroAlgos": 3846899481,
+        "RewardedMicroAlgos": 0,
+        "RewardsBase": 0,
+        "SelectionID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "StateProofID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "Status": 2,
+        "TotalAppLocalStates": 0,
+        "TotalAppParams": 0,
+        "TotalAppSchema": {},
+        "TotalAssetParams": 0,
+        "TotalAssets": 0,
+        "TotalBoxBytes": 0,
+        "TotalBoxes": 0,
+        "TotalExtraAppPages": 0,
+        "VoteFirstValid": 0,
+        "VoteID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "VoteKeyDilution": 0,
+        "VoteLastValid": 0
+      },
+      {
+        "Addr": "TEMFLLX3MYP533ZSVGD6LGKGMGLGVA6KPMK67W4QWBC64RKBR6IDEPINDA",
+        "AuthAddr": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ",
+        "MicroAlgos": 89597001,
+        "RewardedMicroAlgos": 0,
+        "RewardsBase": 12595,
+        "SelectionID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "StateProofID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "Status": 0,
+        "TotalAppLocalStates": 0,
+        "TotalAppParams": 0,
+        "TotalAppSchema": {},
+        "TotalAssetParams": 0,
+        "TotalAssets": 0,
+        "TotalBoxBytes": 0,
+        "TotalBoxes": 0,
+        "TotalExtraAppPages": 0,
+        "VoteFirstValid": 0,
+        "VoteID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "VoteKeyDilution": 0,
+        "VoteLastValid": 0
+      },
+      {
+        "Addr": "A7NMWS3NT3IUDMLVO26ULGXGIIOUQ3ND2TXSER6EBGRZNOBOUIQXHIBGDE",
+        "AuthAddr": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ",
+        "MicroAlgos": 1357799888809,
+        "RewardedMicroAlgos": 0,
+        "RewardsBase": 0,
+        "SelectionID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "StateProofID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "Status": 2,
+        "TotalAppLocalStates": 0,
+        "TotalAppParams": 0,
+        "TotalAppSchema": {},
+        "TotalAssetParams": 0,
+        "TotalAssets": 0,
+        "TotalBoxBytes": 0,
+        "TotalBoxes": 0,
+        "TotalExtraAppPages": 0,
+        "VoteFirstValid": 0,
+        "VoteID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "VoteKeyDilution": 0,
+        "VoteLastValid": 0
+      },
+      {
+        "Addr": "NWEGGPZBAUDMPD5A2LP3IYDCXPKGJUIRILRYEMJETTSMV5WO6CSMEAL5NU",
+        "AuthAddr": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ",
+        "MicroAlgos": 89596000,
+        "RewardedMicroAlgos": 0,
+        "RewardsBase": 12595,
+        "SelectionID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "StateProofID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "Status": 0,
+        "TotalAppLocalStates": 0,
+        "TotalAppParams": 0,
+        "TotalAppSchema": {},
+        "TotalAssetParams": 0,
+        "TotalAssets": 0,
+        "TotalBoxBytes": 0,
+        "TotalBoxes": 0,
+        "TotalExtraAppPages": 0,
+        "VoteFirstValid": 0,
+        "VoteID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "VoteKeyDilution": 0,
+        "VoteLastValid": 0
+      },
+      {
+        "Addr": "K5FBUPVCO3NOKVU67J7COAGYRZVF6JPXWOAOZ2V7NGK3WMIBMH3BL6IGMY",
+        "AuthAddr": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ",
+        "MicroAlgos": 89595999,
+        "RewardedMicroAlgos": 0,
+        "RewardsBase": 12595,
+        "SelectionID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "StateProofID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "Status": 0,
+        "TotalAppLocalStates": 0,
+        "TotalAppParams": 0,
+        "TotalAppSchema": {},
+        "TotalAssetParams": 0,
+        "TotalAssets": 0,
+        "TotalBoxBytes": 0,
+        "TotalBoxes": 0,
+        "TotalExtraAppPages": 0,
+        "VoteFirstValid": 0,
+        "VoteID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "VoteKeyDilution": 0,
+        "VoteLastValid": 0
+      },
+      {
+        "Addr": "FMXWIYDRWURPWVTEGDRWCHLXKY3SE5K2YVFIK5IXGBLI3OGH5DVE6DKYWY",
+        "AuthAddr": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ",
+        "MicroAlgos": 89596000,
+        "RewardedMicroAlgos": 0,
+        "RewardsBase": 12595,
+        "SelectionID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "StateProofID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "Status": 0,
+        "TotalAppLocalStates": 0,
+        "TotalAppParams": 0,
+        "TotalAppSchema": {},
+        "TotalAssetParams": 0,
+        "TotalAssets": 0,
+        "TotalBoxBytes": 0,
+        "TotalBoxes": 0,
+        "TotalExtraAppPages": 0,
+        "VoteFirstValid": 0,
+        "VoteID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "VoteKeyDilution": 0,
+        "VoteLastValid": 0
+      },
+      {
+        "Addr": "DC5NRFRRXVLP5GBD4D6SQJX53YQ2EX7PL3DMP7Z4DOTX2GGTYCD4XTET5E",
+        "AuthAddr": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ",
+        "MicroAlgos": 89596000,
+        "RewardedMicroAlgos": 0,
+        "RewardsBase": 12595,
+        "SelectionID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "StateProofID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "Status": 0,
+        "TotalAppLocalStates": 0,
+        "TotalAppParams": 0,
+        "TotalAppSchema": {},
+        "TotalAssetParams": 0,
+        "TotalAssets": 0,
+        "TotalBoxBytes": 0,
+        "TotalBoxes": 0,
+        "TotalExtraAppPages": 0,
+        "VoteFirstValid": 0,
+        "VoteID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "VoteKeyDilution": 0,
+        "VoteLastValid": 0
+      },
+      {
+        "Addr": "YAC5FU3BXY4YE6KG42SHCDKR34NHYSNT3UPILEZOAKYFADXL2CKUF6AQCI",
+        "AuthAddr": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ",
+        "MicroAlgos": 89596000,
+        "RewardedMicroAlgos": 0,
+        "RewardsBase": 12595,
+        "SelectionID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "StateProofID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "Status": 0,
+        "TotalAppLocalStates": 0,
+        "TotalAppParams": 0,
+        "TotalAppSchema": {},
+        "TotalAssetParams": 0,
+        "TotalAssets": 0,
+        "TotalBoxBytes": 0,
+        "TotalBoxes": 0,
+        "TotalExtraAppPages": 0,
+        "VoteFirstValid": 0,
+        "VoteID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "VoteKeyDilution": 0,
+        "VoteLastValid": 0
+      },
+      {
+        "Addr": "CFDBH6JMUVYXW5WICVJS3IMSET762FJOHHAX72YO4H6ZDGHFWDB5QYFABI",
+        "AuthAddr": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ",
+        "MicroAlgos": 89595999,
+        "RewardedMicroAlgos": 0,
+        "RewardsBase": 12595,
+        "SelectionID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "StateProofID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "Status": 0,
+        "TotalAppLocalStates": 0,
+        "TotalAppParams": 0,
+        "TotalAppSchema": {},
+        "TotalAssetParams": 0,
+        "TotalAssets": 0,
+        "TotalBoxBytes": 0,
+        "TotalBoxes": 0,
+        "TotalExtraAppPages": 0,
+        "VoteFirstValid": 0,
+        "VoteID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "VoteKeyDilution": 0,
+        "VoteLastValid": 0
+      },
+      {
+        "Addr": "ZV7U5N75SPGYKSTUI5MNN675HY5X6VXGOK6XUZXGC4AN7765TEEUP5SAW4",
+        "AuthAddr": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ",
+        "MicroAlgos": 89596000,
+        "RewardedMicroAlgos": 0,
+        "RewardsBase": 12595,
+        "SelectionID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "StateProofID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "Status": 0,
+        "TotalAppLocalStates": 0,
+        "TotalAppParams": 0,
+        "TotalAppSchema": {},
+        "TotalAssetParams": 0,
+        "TotalAssets": 0,
+        "TotalBoxBytes": 0,
+        "TotalBoxes": 0,
+        "TotalExtraAppPages": 0,
+        "VoteFirstValid": 0,
+        "VoteID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "VoteKeyDilution": 0,
+        "VoteLastValid": 0
+      },
+      {
+        "Addr": "A5BSFUM372UQJFMAYIE2LSNGOO7KBAWFWW6BMSSHYRC7Y2QB53DMAI6OHM",
+        "AuthAddr": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ",
+        "MicroAlgos": 89596000,
+        "RewardedMicroAlgos": 0,
+        "RewardsBase": 12595,
+        "SelectionID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "StateProofID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "Status": 0,
+        "TotalAppLocalStates": 0,
+        "TotalAppParams": 0,
+        "TotalAppSchema": {},
+        "TotalAssetParams": 0,
+        "TotalAssets": 0,
+        "TotalBoxBytes": 0,
+        "TotalBoxes": 0,
+        "TotalExtraAppPages": 0,
+        "VoteFirstValid": 0,
+        "VoteID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "VoteKeyDilution": 0,
+        "VoteLastValid": 0
+      },
+      {
+        "Addr": "ZTCH4N4X5XIJQYUFBG6VQNEZC5QPMPZFJXRARMTDQ6WMSGKXNPXXRNGVNE",
+        "AuthAddr": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ",
+        "MicroAlgos": 89597001,
+        "RewardedMicroAlgos": 0,
+        "RewardsBase": 12595,
+        "SelectionID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "StateProofID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "Status": 0,
+        "TotalAppLocalStates": 0,
+        "TotalAppParams": 0,
+        "TotalAppSchema": {},
+        "TotalAssetParams": 0,
+        "TotalAssets": 0,
+        "TotalBoxBytes": 0,
+        "TotalBoxes": 0,
+        "TotalExtraAppPages": 0,
+        "VoteFirstValid": 0,
+        "VoteID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "VoteKeyDilution": 0,
+        "VoteLastValid": 0
+      },
+      {
+        "Addr": "TSTX3UHLEREFVRIYMXJEIPMQ7GD7FYCIH3VSVDJNQ564KLRBWGFNXBD2LM",
+        "AuthAddr": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ",
+        "MicroAlgos": 89597001,
+        "RewardedMicroAlgos": 0,
+        "RewardsBase": 12595,
+        "SelectionID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "StateProofID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "Status": 0,
+        "TotalAppLocalStates": 0,
+        "TotalAppParams": 0,
+        "TotalAppSchema": {},
+        "TotalAssetParams": 0,
+        "TotalAssets": 0,
+        "TotalBoxBytes": 0,
+        "TotalBoxes": 0,
+        "TotalExtraAppPages": 0,
+        "VoteFirstValid": 0,
+        "VoteID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "VoteKeyDilution": 0,
+        "VoteLastValid": 0
+      },
+      {
+        "Addr": "MUGZIV7HAYUEL5WKZGZ5QSBTMDSTAEYZVDJMAPEWR7RTD2CP4LH244LZII",
+        "AuthAddr": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ",
+        "MicroAlgos": 89596000,
+        "RewardedMicroAlgos": 0,
+        "RewardsBase": 12595,
+        "SelectionID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "StateProofID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "Status": 0,
+        "TotalAppLocalStates": 0,
+        "TotalAppParams": 0,
+        "TotalAppSchema": {},
+        "TotalAssetParams": 0,
+        "TotalAssets": 0,
+        "TotalBoxBytes": 0,
+        "TotalBoxes": 0,
+        "TotalExtraAppPages": 0,
+        "VoteFirstValid": 0,
+        "VoteID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "VoteKeyDilution": 0,
+        "VoteLastValid": 0
+      },
+      {
+        "Addr": "RTGQDNMNKV5JD2NVZXRMP3CYVIMTYDIEEZT65VNCFS2TTP32Y45IGMDTLM",
+        "AuthAddr": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ",
+        "MicroAlgos": 89595999,
+        "RewardedMicroAlgos": 0,
+        "RewardsBase": 12595,
+        "SelectionID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "StateProofID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "Status": 0,
+        "TotalAppLocalStates": 0,
+        "TotalAppParams": 0,
+        "TotalAppSchema": {},
+        "TotalAssetParams": 0,
+        "TotalAssets": 0,
+        "TotalBoxBytes": 0,
+        "TotalBoxes": 0,
+        "TotalExtraAppPages": 0,
+        "VoteFirstValid": 0,
+        "VoteID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "VoteKeyDilution": 0,
+        "VoteLastValid": 0
+      },
+      {
+        "Addr": "NIG3G7OLUYVKTWVWZNSYBV46NSAETY22VXREHQ4GZDATUZM4QBZAVCYTME",
+        "AuthAddr": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ",
+        "MicroAlgos": 89596000,
+        "RewardedMicroAlgos": 0,
+        "RewardsBase": 12595,
+        "SelectionID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "StateProofID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "Status": 0,
+        "TotalAppLocalStates": 0,
+        "TotalAppParams": 0,
+        "TotalAppSchema": {},
+        "TotalAssetParams": 0,
+        "TotalAssets": 0,
+        "TotalBoxBytes": 0,
+        "TotalBoxes": 0,
+        "TotalExtraAppPages": 0,
+        "VoteFirstValid": 0,
+        "VoteID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "VoteKeyDilution": 0,
+        "VoteLastValid": 0
+      },
+      {
+        "Addr": "MZUVMPKMLALQQMO3FIXHL5XJY477KXSOGLRPECI2NVG5I7SBABDOKYKET4",
+        "AuthAddr": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ",
+        "MicroAlgos": 89596000,
+        "RewardedMicroAlgos": 0,
+        "RewardsBase": 12595,
+        "SelectionID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "StateProofID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "Status": 0,
+        "TotalAppLocalStates": 0,
+        "TotalAppParams": 0,
+        "TotalAppSchema": {},
+        "TotalAssetParams": 0,
+        "TotalAssets": 0,
+        "TotalBoxBytes": 0,
+        "TotalBoxes": 0,
+        "TotalExtraAppPages": 0,
+        "VoteFirstValid": 0,
+        "VoteID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "VoteKeyDilution": 0,
+        "VoteLastValid": 0
+      },
+      {
+        "Addr": "DLZMUYCBOMZKXLPRPJW6XRRU7XPK4ATKJ4IHZUKZSO5SDALKN2LQ4GSM3Q",
+        "AuthAddr": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ",
+        "MicroAlgos": 89595999,
+        "RewardedMicroAlgos": 0,
+        "RewardsBase": 12595,
+        "SelectionID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "StateProofID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "Status": 0,
+        "TotalAppLocalStates": 0,
+        "TotalAppParams": 0,
+        "TotalAppSchema": {},
+        "TotalAssetParams": 0,
+        "TotalAssets": 0,
+        "TotalBoxBytes": 0,
+        "TotalBoxes": 0,
+        "TotalExtraAppPages": 0,
+        "VoteFirstValid": 0,
+        "VoteID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "VoteKeyDilution": 0,
+        "VoteLastValid": 0
+      },
+      {
+        "Addr": "GHRJXNQG2TDSRTL2T3BYTTPKMMHLCI6UBGAWYCFXDR5YU674KK23P72G7Y",
+        "AuthAddr": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ",
+        "MicroAlgos": 89596000,
+        "RewardedMicroAlgos": 0,
+        "RewardsBase": 12595,
+        "SelectionID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "StateProofID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "Status": 0,
+        "TotalAppLocalStates": 0,
+        "TotalAppParams": 0,
+        "TotalAppSchema": {},
+        "TotalAssetParams": 0,
+        "TotalAssets": 0,
+        "TotalBoxBytes": 0,
+        "TotalBoxes": 0,
+        "TotalExtraAppPages": 0,
+        "VoteFirstValid": 0,
+        "VoteID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "VoteKeyDilution": 0,
+        "VoteLastValid": 0
+      },
+      {
+        "Addr": "NVBQCX2EMMGKKSD5VV4OSPKK2YPEOEIBJHMVBSNP7IX3IDTLIIJ72LBU6M",
+        "AuthAddr": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ",
+        "MicroAlgos": 89597001,
+        "RewardedMicroAlgos": 0,
+        "RewardsBase": 12595,
+        "SelectionID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "StateProofID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "Status": 0,
+        "TotalAppLocalStates": 0,
+        "TotalAppParams": 0,
+        "TotalAppSchema": {},
+        "TotalAssetParams": 0,
+        "TotalAssets": 0,
+        "TotalBoxBytes": 0,
+        "TotalBoxes": 0,
+        "TotalExtraAppPages": 0,
+        "VoteFirstValid": 0,
+        "VoteID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "VoteKeyDilution": 0,
+        "VoteLastValid": 0
+      },
+      {
+        "Addr": "O67HT3XCCJEQREBUCKXZ5RR7TAKCSDJQL4ROUVDZFKM2R75YUZ5SVUYAIY",
+        "AuthAddr": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ",
+        "MicroAlgos": 89596000,
+        "RewardedMicroAlgos": 0,
+        "RewardsBase": 12595,
+        "SelectionID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "StateProofID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "Status": 0,
+        "TotalAppLocalStates": 0,
+        "TotalAppParams": 0,
+        "TotalAppSchema": {},
+        "TotalAssetParams": 0,
+        "TotalAssets": 0,
+        "TotalBoxBytes": 0,
+        "TotalBoxes": 0,
+        "TotalExtraAppPages": 0,
+        "VoteFirstValid": 0,
+        "VoteID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "VoteKeyDilution": 0,
+        "VoteLastValid": 0
+      },
+      {
+        "Addr": "7GHMIAXV32NH45DW76M7BIPWEKKIM4UAV5HV6KLJUZUFQL5MFKDPK65CRM",
+        "AuthAddr": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ",
+        "MicroAlgos": 89596000,
+        "RewardedMicroAlgos": 0,
+        "RewardsBase": 12595,
+        "SelectionID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "StateProofID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "Status": 0,
+        "TotalAppLocalStates": 0,
+        "TotalAppParams": 0,
+        "TotalAppSchema": {},
+        "TotalAssetParams": 0,
+        "TotalAssets": 0,
+        "TotalBoxBytes": 0,
+        "TotalBoxes": 0,
+        "TotalExtraAppPages": 0,
+        "VoteFirstValid": 0,
+        "VoteID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "VoteKeyDilution": 0,
+        "VoteLastValid": 0
+      },
+      {
+        "Addr": "KW4A6PAMITUM6DQSAGS5H326H426DDWPZ42ZCG7Z7OTDDB7LDZACSEJS4I",
+        "AuthAddr": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ",
+        "MicroAlgos": 89597001,
+        "RewardedMicroAlgos": 0,
+        "RewardsBase": 12595,
+        "SelectionID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "StateProofID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "Status": 0,
+        "TotalAppLocalStates": 0,
+        "TotalAppParams": 0,
+        "TotalAppSchema": {},
+        "TotalAssetParams": 0,
+        "TotalAssets": 0,
+        "TotalBoxBytes": 0,
+        "TotalBoxes": 0,
+        "TotalExtraAppPages": 0,
+        "VoteFirstValid": 0,
+        "VoteID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "VoteKeyDilution": 0,
+        "VoteLastValid": 0
+      },
+      {
+        "Addr": "CFKJBVYLCCF7ZHK7AHVYPDA4YAXHN3SHSZL62PKW5TXFSXL4EPWNWAI6TY",
+        "AuthAddr": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ",
+        "MicroAlgos": 89597001,
+        "RewardedMicroAlgos": 0,
+        "RewardsBase": 12595,
+        "SelectionID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "StateProofID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "Status": 0,
+        "TotalAppLocalStates": 0,
+        "TotalAppParams": 0,
+        "TotalAppSchema": {},
+        "TotalAssetParams": 0,
+        "TotalAssets": 0,
+        "TotalBoxBytes": 0,
+        "TotalBoxes": 0,
+        "TotalExtraAppPages": 0,
+        "VoteFirstValid": 0,
+        "VoteID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "VoteKeyDilution": 0,
+        "VoteLastValid": 0
+      },
+      {
+        "Addr": "XOKMFT7DIZSA2YR7P2HUHMJDOVNY24N6367TUM4HUUQI32VB6OGUXSAVJY",
+        "AuthAddr": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ",
+        "MicroAlgos": 89596000,
+        "RewardedMicroAlgos": 0,
+        "RewardsBase": 12595,
+        "SelectionID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "StateProofID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "Status": 0,
+        "TotalAppLocalStates": 0,
+        "TotalAppParams": 0,
+        "TotalAppSchema": {},
+        "TotalAssetParams": 0,
+        "TotalAssets": 0,
+        "TotalBoxBytes": 0,
+        "TotalBoxes": 0,
+        "TotalExtraAppPages": 0,
+        "VoteFirstValid": 0,
+        "VoteID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "VoteKeyDilution": 0,
+        "VoteLastValid": 0
+      },
+      {
+        "Addr": "HAA6FOTDZ2HZNQHLQNHZRINF42YUEUHWAZOT2KXUZGQ3VDBBDNCOEKCTPY",
+        "AuthAddr": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ",
+        "MicroAlgos": 89595999,
+        "RewardedMicroAlgos": 0,
+        "RewardsBase": 12595,
+        "SelectionID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "StateProofID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "Status": 0,
+        "TotalAppLocalStates": 0,
+        "TotalAppParams": 0,
+        "TotalAppSchema": {},
+        "TotalAssetParams": 0,
+        "TotalAssets": 0,
+        "TotalBoxBytes": 0,
+        "TotalBoxes": 0,
+        "TotalExtraAppPages": 0,
+        "VoteFirstValid": 0,
+        "VoteID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "VoteKeyDilution": 0,
+        "VoteLastValid": 0
+      },
+      {
+        "Addr": "SHX4ZXOQPN3VBEYRCW6TSOJXP66SLRSNUIYFHAZ6UF3ACOIJJLQEZ4LQRQ",
+        "AuthAddr": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ",
+        "MicroAlgos": 89597001,
+        "RewardedMicroAlgos": 0,
+        "RewardsBase": 12595,
+        "SelectionID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "StateProofID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "Status": 0,
+        "TotalAppLocalStates": 0,
+        "TotalAppParams": 0,
+        "TotalAppSchema": {},
+        "TotalAssetParams": 0,
+        "TotalAssets": 0,
+        "TotalBoxBytes": 0,
+        "TotalBoxes": 0,
+        "TotalExtraAppPages": 0,
+        "VoteFirstValid": 0,
+        "VoteID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "VoteKeyDilution": 0,
+        "VoteLastValid": 0
+      },
+      {
+        "Addr": "VV2QFIZENH663VOS2GJKAITIQWHHQLCR7AQBRV7EUSD5FYX2P3X6LUE6LI",
+        "AuthAddr": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ",
+        "MicroAlgos": 89597001,
+        "RewardedMicroAlgos": 0,
+        "RewardsBase": 12595,
+        "SelectionID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "StateProofID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "Status": 0,
+        "TotalAppLocalStates": 0,
+        "TotalAppParams": 0,
+        "TotalAppSchema": {},
+        "TotalAssetParams": 0,
+        "TotalAssets": 0,
+        "TotalBoxBytes": 0,
+        "TotalBoxes": 0,
+        "TotalExtraAppPages": 0,
+        "VoteFirstValid": 0,
+        "VoteID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "VoteKeyDilution": 0,
+        "VoteLastValid": 0
+      },
+      {
+        "Addr": "SBKZAOS3LYASTCTSBHJMC52Y45OOMYMY4XSLLBASGN6GBJOEARUKPOZ3BE",
+        "AuthAddr": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ",
+        "MicroAlgos": 89596000,
+        "RewardedMicroAlgos": 0,
+        "RewardsBase": 12595,
+        "SelectionID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "StateProofID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "Status": 0,
+        "TotalAppLocalStates": 0,
+        "TotalAppParams": 0,
+        "TotalAppSchema": {},
+        "TotalAssetParams": 0,
+        "TotalAssets": 0,
+        "TotalBoxBytes": 0,
+        "TotalBoxes": 0,
+        "TotalExtraAppPages": 0,
+        "VoteFirstValid": 0,
+        "VoteID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "VoteKeyDilution": 0,
+        "VoteLastValid": 0
+      },
+      {
+        "Addr": "LMJAMWEDZE7AL25VXBQH4OUEMRZ3XNH6Y76PRU4BW2262UBHTM34J5R42Y",
+        "AuthAddr": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ",
+        "MicroAlgos": 89596000,
+        "RewardedMicroAlgos": 0,
+        "RewardsBase": 12595,
+        "SelectionID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "StateProofID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "Status": 0,
+        "TotalAppLocalStates": 0,
+        "TotalAppParams": 0,
+        "TotalAppSchema": {},
+        "TotalAssetParams": 0,
+        "TotalAssets": 0,
+        "TotalBoxBytes": 0,
+        "TotalBoxes": 0,
+        "TotalExtraAppPages": 0,
+        "VoteFirstValid": 0,
+        "VoteID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "VoteKeyDilution": 0,
+        "VoteLastValid": 0
+      },
+      {
+        "Addr": "LXKIIYIR44WFWDT37E6QXWDCCMN4DJUDXN2RO5WXBTUVKKN7TQAWKCF6LI",
+        "AuthAddr": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ",
+        "MicroAlgos": 89596000,
+        "RewardedMicroAlgos": 0,
+        "RewardsBase": 12595,
+        "SelectionID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "StateProofID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "Status": 0,
+        "TotalAppLocalStates": 0,
+        "TotalAppParams": 0,
+        "TotalAppSchema": {},
+        "TotalAssetParams": 0,
+        "TotalAssets": 0,
+        "TotalBoxBytes": 0,
+        "TotalBoxes": 0,
+        "TotalExtraAppPages": 0,
+        "VoteFirstValid": 0,
+        "VoteID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "VoteKeyDilution": 0,
+        "VoteLastValid": 0
+      },
+      {
+        "Addr": "F53X3524HL6SNVHCKC252PYFH3FAWZAE46TFFL3PO62RJRQYKGUGO3JMZU",
+        "AuthAddr": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ",
+        "MicroAlgos": 89597001,
+        "RewardedMicroAlgos": 0,
+        "RewardsBase": 12595,
+        "SelectionID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "StateProofID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "Status": 0,
+        "TotalAppLocalStates": 0,
+        "TotalAppParams": 0,
+        "TotalAppSchema": {},
+        "TotalAssetParams": 0,
+        "TotalAssets": 0,
+        "TotalBoxBytes": 0,
+        "TotalBoxes": 0,
+        "TotalExtraAppPages": 0,
+        "VoteFirstValid": 0,
+        "VoteID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "VoteKeyDilution": 0,
+        "VoteLastValid": 0
+      },
+      {
+        "Addr": "XXVPWGGU4OICADPUBP6B3RBYGQXOTUEYBM6D4UKAZUBJNY5Z3Y4CQLUUCY",
+        "AuthAddr": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ",
+        "MicroAlgos": 89596000,
+        "RewardedMicroAlgos": 0,
+        "RewardsBase": 12595,
+        "SelectionID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "StateProofID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "Status": 0,
+        "TotalAppLocalStates": 0,
+        "TotalAppParams": 0,
+        "TotalAppSchema": {},
+        "TotalAssetParams": 0,
+        "TotalAssets": 0,
+        "TotalBoxBytes": 0,
+        "TotalBoxes": 0,
+        "TotalExtraAppPages": 0,
+        "VoteFirstValid": 0,
+        "VoteID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "VoteKeyDilution": 0,
+        "VoteLastValid": 0
+      },
+      {
+        "Addr": "L3UDQSJYGSLFEWRRTNMV75IQWZSEB2SUKMO6IYKFIDPTWJPVQTZDOVQRG4",
+        "AuthAddr": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ",
+        "MicroAlgos": 89597000,
+        "RewardedMicroAlgos": 0,
+        "RewardsBase": 12595,
+        "SelectionID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "StateProofID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "Status": 0,
+        "TotalAppLocalStates": 0,
+        "TotalAppParams": 0,
+        "TotalAppSchema": {},
+        "TotalAssetParams": 0,
+        "TotalAssets": 0,
+        "TotalBoxBytes": 0,
+        "TotalBoxes": 0,
+        "TotalExtraAppPages": 0,
+        "VoteFirstValid": 0,
+        "VoteID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "VoteKeyDilution": 0,
+        "VoteLastValid": 0
+      },
+      {
+        "Addr": "C25LZV5N6N2TYEIH4WE5KBWQIGBWAA2TLZXW36PDNMTUHGQXRMSDVXKP6U",
+        "AuthAddr": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ",
+        "MicroAlgos": 89596000,
+        "RewardedMicroAlgos": 0,
+        "RewardsBase": 12595,
+        "SelectionID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "StateProofID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "Status": 0,
+        "TotalAppLocalStates": 0,
+        "TotalAppParams": 0,
+        "TotalAppSchema": {},
+        "TotalAssetParams": 0,
+        "TotalAssets": 0,
+        "TotalBoxBytes": 0,
+        "TotalBoxes": 0,
+        "TotalExtraAppPages": 0,
+        "VoteFirstValid": 0,
+        "VoteID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "VoteKeyDilution": 0,
+        "VoteLastValid": 0
+      },
+      {
+        "Addr": "X5PEDKFAOTUUGPZFKVBJQLUMGT6RK6356F4KFRNIYMNCEQXCHIOZBQXBI4",
+        "AuthAddr": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ",
+        "MicroAlgos": 89596000,
+        "RewardedMicroAlgos": 0,
+        "RewardsBase": 12595,
+        "SelectionID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "StateProofID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "Status": 0,
+        "TotalAppLocalStates": 0,
+        "TotalAppParams": 0,
+        "TotalAppSchema": {},
+        "TotalAssetParams": 0,
+        "TotalAssets": 0,
+        "TotalBoxBytes": 0,
+        "TotalBoxes": 0,
+        "TotalExtraAppPages": 0,
+        "VoteFirstValid": 0,
+        "VoteID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "VoteKeyDilution": 0,
+        "VoteLastValid": 0
+      },
+      {
+        "Addr": "MH63GZDAFEFNFU6T37NOBUA24TMDZ5AIQGNYSPUHTA53MXPWLHUUDCNZXA",
+        "AuthAddr": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ",
+        "MicroAlgos": 89596000,
+        "RewardedMicroAlgos": 0,
+        "RewardsBase": 12595,
+        "SelectionID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "StateProofID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "Status": 0,
+        "TotalAppLocalStates": 0,
+        "TotalAppParams": 0,
+        "TotalAppSchema": {},
+        "TotalAssetParams": 0,
+        "TotalAssets": 0,
+        "TotalBoxBytes": 0,
+        "TotalBoxes": 0,
+        "TotalExtraAppPages": 0,
+        "VoteFirstValid": 0,
+        "VoteID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "VoteKeyDilution": 0,
+        "VoteLastValid": 0
+      },
+      {
+        "Addr": "TUHO4M5UDEAKHTK4VIGOABW5FQ7LFWV6HPEOORC4EF6OONOMLUTATEVESI",
+        "AuthAddr": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ",
+        "MicroAlgos": 89597000,
+        "RewardedMicroAlgos": 0,
+        "RewardsBase": 12595,
+        "SelectionID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "StateProofID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "Status": 0,
+        "TotalAppLocalStates": 0,
+        "TotalAppParams": 0,
+        "TotalAppSchema": {},
+        "TotalAssetParams": 0,
+        "TotalAssets": 0,
+        "TotalBoxBytes": 0,
+        "TotalBoxes": 0,
+        "TotalExtraAppPages": 0,
+        "VoteFirstValid": 0,
+        "VoteID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "VoteKeyDilution": 0,
+        "VoteLastValid": 0
+      },
+      {
+        "Addr": "EYZIF2CV2RP2PXEXIXWYLHCC37XPOIOOJRWLYZHDDR3KN2AO6YGUY7VF3M",
+        "AuthAddr": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ",
+        "MicroAlgos": 89596000,
+        "RewardedMicroAlgos": 0,
+        "RewardsBase": 12595,
+        "SelectionID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "StateProofID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "Status": 0,
+        "TotalAppLocalStates": 0,
+        "TotalAppParams": 0,
+        "TotalAppSchema": {},
+        "TotalAssetParams": 0,
+        "TotalAssets": 0,
+        "TotalBoxBytes": 0,
+        "TotalBoxes": 0,
+        "TotalExtraAppPages": 0,
+        "VoteFirstValid": 0,
+        "VoteID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "VoteKeyDilution": 0,
+        "VoteLastValid": 0
+      },
+      {
+        "Addr": "C53UBSLCWZXMTKTGSUA5IGSCMNPEE5X4YJWNDQ4DQT4OJCK346WUBZGY24",
+        "AuthAddr": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ",
+        "MicroAlgos": 89597001,
+        "RewardedMicroAlgos": 0,
+        "RewardsBase": 12595,
+        "SelectionID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "StateProofID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "Status": 0,
+        "TotalAppLocalStates": 0,
+        "TotalAppParams": 0,
+        "TotalAppSchema": {},
+        "TotalAssetParams": 0,
+        "TotalAssets": 0,
+        "TotalBoxBytes": 0,
+        "TotalBoxes": 0,
+        "TotalExtraAppPages": 0,
+        "VoteFirstValid": 0,
+        "VoteID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "VoteKeyDilution": 0,
+        "VoteLastValid": 0
+      },
+      {
+        "Addr": "GS5Y37IBMT4ZLKCSA437K3HCAXX6ANFIQ2RCPFFQH7OUBW7VOJ5HVQURU4",
+        "AuthAddr": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ",
+        "MicroAlgos": 89597000,
+        "RewardedMicroAlgos": 0,
+        "RewardsBase": 12595,
+        "SelectionID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "StateProofID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "Status": 0,
+        "TotalAppLocalStates": 0,
+        "TotalAppParams": 0,
+        "TotalAppSchema": {},
+        "TotalAssetParams": 0,
+        "TotalAssets": 0,
+        "TotalBoxBytes": 0,
+        "TotalBoxes": 0,
+        "TotalExtraAppPages": 0,
+        "VoteFirstValid": 0,
+        "VoteID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "VoteKeyDilution": 0,
+        "VoteLastValid": 0
+      },
+      {
+        "Addr": "BQFFCSTIURAW6ECX4MJG5GYR3GJ4TIJJ7OC7BIJ6EOZSHOHSTEZTYOGZDY",
+        "AuthAddr": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ",
+        "MicroAlgos": 89596000,
+        "RewardedMicroAlgos": 0,
+        "RewardsBase": 12595,
+        "SelectionID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "StateProofID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "Status": 0,
+        "TotalAppLocalStates": 0,
+        "TotalAppParams": 0,
+        "TotalAppSchema": {},
+        "TotalAssetParams": 0,
+        "TotalAssets": 0,
+        "TotalBoxBytes": 0,
+        "TotalBoxes": 0,
+        "TotalExtraAppPages": 0,
+        "VoteFirstValid": 0,
+        "VoteID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "VoteKeyDilution": 0,
+        "VoteLastValid": 0
+      },
+      {
+        "Addr": "NCAJK7KNJBLJPGI3XZV5YHALBAJRS63LNCU6RSLSGTECLOMRLQ5YABWTGU",
+        "AuthAddr": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ",
+        "MicroAlgos": 89595999,
+        "RewardedMicroAlgos": 0,
+        "RewardsBase": 12595,
+        "SelectionID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "StateProofID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "Status": 0,
+        "TotalAppLocalStates": 0,
+        "TotalAppParams": 0,
+        "TotalAppSchema": {},
+        "TotalAssetParams": 0,
+        "TotalAssets": 0,
+        "TotalBoxBytes": 0,
+        "TotalBoxes": 0,
+        "TotalExtraAppPages": 0,
+        "VoteFirstValid": 0,
+        "VoteID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "VoteKeyDilution": 0,
+        "VoteLastValid": 0
+      },
+      {
+        "Addr": "MIXOPVJHGDMEHX76OUNVPSDANFNGS5HM5RYSRQ3VJ5VG6D6FNOUUDAVF7U",
+        "AuthAddr": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ",
+        "MicroAlgos": 89596000,
+        "RewardedMicroAlgos": 0,
+        "RewardsBase": 12595,
+        "SelectionID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "StateProofID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "Status": 0,
+        "TotalAppLocalStates": 0,
+        "TotalAppParams": 0,
+        "TotalAppSchema": {},
+        "TotalAssetParams": 0,
+        "TotalAssets": 0,
+        "TotalBoxBytes": 0,
+        "TotalBoxes": 0,
+        "TotalExtraAppPages": 0,
+        "VoteFirstValid": 0,
+        "VoteID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "VoteKeyDilution": 0,
+        "VoteLastValid": 0
+      },
+      {
+        "Addr": "BOK46E3YACLU64QM4K7KEVBH3AZJI5K2P7MC5HTYTDORNJKPSBGTVEZ4KA",
+        "AuthAddr": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ",
+        "MicroAlgos": 89595999,
+        "RewardedMicroAlgos": 0,
+        "RewardsBase": 12595,
+        "SelectionID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "StateProofID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "Status": 0,
+        "TotalAppLocalStates": 0,
+        "TotalAppParams": 0,
+        "TotalAppSchema": {},
+        "TotalAssetParams": 0,
+        "TotalAssets": 0,
+        "TotalBoxBytes": 0,
+        "TotalBoxes": 0,
+        "TotalExtraAppPages": 0,
+        "VoteFirstValid": 0,
+        "VoteID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "VoteKeyDilution": 0,
+        "VoteLastValid": 0
+      },
+      {
+        "Addr": "2V3AQNCE7DJE76WIGBN6KT6IYUFU6G4GXFW6VX5574SQX5FEA53Z7W2LIA",
+        "AuthAddr": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ",
+        "MicroAlgos": 39996000,
+        "RewardedMicroAlgos": 0,
+        "RewardsBase": 12595,
+        "SelectionID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "StateProofID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "Status": 0,
+        "TotalAppLocalStates": 0,
+        "TotalAppParams": 1,
+        "TotalAppSchema": {
+          "nui": 11
+        },
+        "TotalAssetParams": 0,
+        "TotalAssets": 0,
+        "TotalBoxBytes": 0,
+        "TotalBoxes": 0,
+        "TotalExtraAppPages": 0,
+        "VoteFirstValid": 0,
+        "VoteID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "VoteKeyDilution": 0,
+        "VoteLastValid": 0
+      },
+      {
+        "Addr": "RZK74A7BE4ECUMCVNTFWWKSAOSFRVEXGJ3S3R673O47AQULVCSCAAXQ6Y4",
+        "AuthAddr": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ",
+        "MicroAlgos": 89596000,
+        "RewardedMicroAlgos": 0,
+        "RewardsBase": 12595,
+        "SelectionID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "StateProofID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "Status": 0,
+        "TotalAppLocalStates": 0,
+        "TotalAppParams": 0,
+        "TotalAppSchema": {},
+        "TotalAssetParams": 0,
+        "TotalAssets": 0,
+        "TotalBoxBytes": 0,
+        "TotalBoxes": 0,
+        "TotalExtraAppPages": 0,
+        "VoteFirstValid": 0,
+        "VoteID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "VoteKeyDilution": 0,
+        "VoteLastValid": 0
+      },
+      {
+        "Addr": "AXRSQQG7FR6HDBHLR23EURQ7YSL5UU4BED46DALQVQYMTIAKEM37JKB6JA",
+        "AuthAddr": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ",
+        "MicroAlgos": 89596000,
+        "RewardedMicroAlgos": 0,
+        "RewardsBase": 12595,
+        "SelectionID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "StateProofID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "Status": 0,
+        "TotalAppLocalStates": 0,
+        "TotalAppParams": 0,
+        "TotalAppSchema": {},
+        "TotalAssetParams": 0,
+        "TotalAssets": 0,
+        "TotalBoxBytes": 0,
+        "TotalBoxes": 0,
+        "TotalExtraAppPages": 0,
+        "VoteFirstValid": 0,
+        "VoteID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "VoteKeyDilution": 0,
+        "VoteLastValid": 0
+      },
+      {
+        "Addr": "IOEHCOUTUVLM7D626MIAVM4XRLG6M25QI6DP3OPU7LALBZXBQ4UY4H6G4E",
+        "AuthAddr": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ",
+        "MicroAlgos": 89595999,
+        "RewardedMicroAlgos": 0,
+        "RewardsBase": 12595,
+        "SelectionID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "StateProofID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "Status": 0,
+        "TotalAppLocalStates": 0,
+        "TotalAppParams": 0,
+        "TotalAppSchema": {},
+        "TotalAssetParams": 0,
+        "TotalAssets": 0,
+        "TotalBoxBytes": 0,
+        "TotalBoxes": 0,
+        "TotalExtraAppPages": 0,
+        "VoteFirstValid": 0,
+        "VoteID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "VoteKeyDilution": 0,
+        "VoteLastValid": 0
+      },
+      {
+        "Addr": "YENAMUAV4VVB6QR66HADERLE4X24FOROL3U7KW4OK3JWDVADCJL7FRL5YM",
+        "AuthAddr": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ",
+        "MicroAlgos": 89595999,
+        "RewardedMicroAlgos": 0,
+        "RewardsBase": 12595,
+        "SelectionID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "StateProofID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "Status": 0,
+        "TotalAppLocalStates": 0,
+        "TotalAppParams": 0,
+        "TotalAppSchema": {},
+        "TotalAssetParams": 0,
+        "TotalAssets": 0,
+        "TotalBoxBytes": 0,
+        "TotalBoxes": 0,
+        "TotalExtraAppPages": 0,
+        "VoteFirstValid": 0,
+        "VoteID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "VoteKeyDilution": 0,
+        "VoteLastValid": 0
+      },
+      {
+        "Addr": "KQX72RE7MJ7UVJFGHDN5ARONGFKVOLIMKCXPEB7XJCORI5JHGM2WIKCNOM",
+        "AuthAddr": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ",
+        "MicroAlgos": 89596000,
+        "RewardedMicroAlgos": 0,
+        "RewardsBase": 12595,
+        "SelectionID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "StateProofID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "Status": 0,
+        "TotalAppLocalStates": 0,
+        "TotalAppParams": 0,
+        "TotalAppSchema": {},
+        "TotalAssetParams": 0,
+        "TotalAssets": 0,
+        "TotalBoxBytes": 0,
+        "TotalBoxes": 0,
+        "TotalExtraAppPages": 0,
+        "VoteFirstValid": 0,
+        "VoteID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "VoteKeyDilution": 0,
+        "VoteLastValid": 0
+      },
+      {
+        "Addr": "FDYJMXO2NKOYBITMFM4TJC6KUNMLLXGH3I2ROPT544224KK3JW2C6BWTRE",
+        "AuthAddr": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ",
+        "MicroAlgos": 89596000,
+        "RewardedMicroAlgos": 0,
+        "RewardsBase": 12595,
+        "SelectionID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "StateProofID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "Status": 0,
+        "TotalAppLocalStates": 0,
+        "TotalAppParams": 0,
+        "TotalAppSchema": {},
+        "TotalAssetParams": 0,
+        "TotalAssets": 0,
+        "TotalBoxBytes": 0,
+        "TotalBoxes": 0,
+        "TotalExtraAppPages": 0,
+        "VoteFirstValid": 0,
+        "VoteID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "VoteKeyDilution": 0,
+        "VoteLastValid": 0
+      },
+      {
+        "Addr": "OVGKE3ZPIHKSRCFWDCIBKHBJMVKMHAE357KODWPV5ZUE233BOC6RL3LZ6Y",
+        "AuthAddr": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ",
+        "MicroAlgos": 89595999,
+        "RewardedMicroAlgos": 0,
+        "RewardsBase": 12595,
+        "SelectionID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "StateProofID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "Status": 0,
+        "TotalAppLocalStates": 0,
+        "TotalAppParams": 0,
+        "TotalAppSchema": {},
+        "TotalAssetParams": 0,
+        "TotalAssets": 0,
+        "TotalBoxBytes": 0,
+        "TotalBoxes": 0,
+        "TotalExtraAppPages": 0,
+        "VoteFirstValid": 0,
+        "VoteID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "VoteKeyDilution": 0,
+        "VoteLastValid": 0
+      }
+    ],
+    "AppResources": [
+      {
+        "Addr": "2V3AQNCE7DJE76WIGBN6KT6IYUFU6G4GXFW6VX5574SQX5FEA53Z7W2LIA",
+        "Aidx": 1337185129,
+        "Params": {
+          "Deleted": false,
+          "Params": {
+            "approv": "CCAGAAECGPQDgCAmBAhhc2tfYm9vawhiaWRfYm9vawNzZXEDBoEBMRsiEkABGTYaAIAEjsSYgRJAAP02GgCABAnlcRYSQAC4NhoAgATBmHqfEkAAfDYaAIAEvxQd2RJAADg2GgCABEPXgiYSQAABADEZIhIxGCITEEQ2GgEiVTURNhoCIlU1EjYaAyJVNRM0ETQSNBOIA54jQzEZIhIxGCITEEQ2GgEXNQw2GgIXNQ02GgMXNQ42GgQXNQ82GgUXNRA0DDQNNA40DzQQiANaI0MxGSISMRgiExBENhoBFzUINhoCFzUJNhoDFzUKNhoEFzULNAg0CTQKNAuIAyAjQzEZIhIxGCITEEQ2GgEigQgLUzUANhoCFzUBNhoDFzUCNAA0ATQCiAKfNQOABBUffHU0AxZQsCNDMRkiEjEYIhMQRIgCeCNDMRkiEkAAAQAxGCISRIgAAiNDI0M1JDUjNSI0IhUiEjQjFSISEUAALzQkQAAcNCJXAAg0IlcICK5QNCNXAAg0I1cICK5QpUIADzQiVwAQNCNXABCkQgABIok1GzUaNRk0GTQZZDQaFQs0Grs0GTQZZDQaFTQbiAB2NBk0GWQjCGeJNTo1OTU4NTc0NzQ3ZCMJZzQ3NDg0N2Q0OYgAGjQ3NDg0OTQ6iADlNDc0N2Q0Oa8VCzQ5r7uJNSg1JzUmNSU0JTQmNCgLNCi6NSk0JTQnNCgLNCi6NSo0JTQnNCkVCzQpuzQlNCY0KhULNCq7iTUfNR41HTUcNB0iE0EAjyEEgQoINSA0IDIMDUAAbTQdJBgiEkAAXTQdIwkkCjUhNBw0HTQeCzQeujQcNCE0Hgs0Hro0H4j+3kEAUzQcNB00ITQeiP9zNBw0ITQeNB80HDQdNB40HzQgNCFPCU8JTwlPCYj/izUhNSA1HzUeNR01HEIAGjQdJAlC/6CxgQayEIEFshkrsh4rsh+zQv94iTU+NT01PDU7NDw0O2QMQQDXIQSBCgg1PzQ/MgwNQAC1NDw1QDQ8JAsjCDVBNDwkCyQINUI0QTQ7ZAxAAHU0QjQ7ZAxAAEk0QDQ8E0EAmjQ7NDw0QDQ9iP7RNDs0QDQ9ND40OzQ8ND00PjQ/NEA0QTRCTwtPC08LTwuI/4Q1QjVBNUA1PzU+NT01PDU7QgBZNDs0QjQ9CzQ9ujQ7NEA0PQs0Pbo0Poj930H/mzRCNUBC/5Q0OzRBND0LND26NDs0QDQ9CzQ9ujQ+iP28Qf9vNEE1QEL/aLGBBrIQgQWyGSuyHiuyH7NC/zCJKCEFuUQpIQW5RIk1BjUFNQQ0BjUHNARAACA0BTQGiACfNQY0BkEALzQFNAYqKmQjCGcqZIgAakIAHTQFNAaIARk1BjQGQQAPNAU0BioqZCMIZypkiAArNAc0Bgk1BzQHiTVNNUw1SzVKIkSJNVI1UTVQNU81TiJEiTVVNVQ1UyJEiTUWNRU1FDQWNRc0FBY0FxZQNBUWUDUYKTQYIoj9Q4k1LTUsNSs0LTUuNCsWNC4WUDQsFlA1Lyg0LyOI/SSJNTE1MClkIhI0MSISEUAAhikiJQslujUyNDIiWzUzNDKBEFs1NDQzNDAMQABmNDQ0MQ5AACg0MoEIWzU1NDQ0MQk1NjQzFjQ1FlA0NhZQNTIpIjQyFQs0MrsiQgA8KSIlIoj85zQwNDE0NAk0MDQxNDI0MzQ0NDU0Nk8ITwiI/4BOBzU2NTU1NDUzNTI1MTUwQgAGNDGJNDGJiTVENUMoZCISNEQiEhFAAIYoIiULJbo1RTRFIls1RjRFgRBbNUc0RjRDDUAAZjRHNEQOQAAoNEWBCFs1SDRHNEQJNUk0RhY0SBZQNEkWUDVFKCI0RRULNEW7IkIAPCgiJSOI/E00QzRENEcJNEM0RDRFNEY0RzRINElPCE8IiP+ATgc1STVINUc1RjVFNUQ1Q0IABjREiTREiYk=",
+            "clearp": "CIEAQw==",
+            "gs": {
+              "bid_book": {
+                "tt": 2,
+                "ui": 1
+              },
+              "seq": {
+                "tt": 2,
+                "ui": 1
+              }
+            },
+            "gsch": {
+              "nui": 11
+            },
+            "lsch": {
+              "nbs": 1,
+              "nui": 4
+            }
+          }
+        },
+        "State": {
+          "Deleted": false,
+          "LocalState": null
+        }
+      }
+    ],
+    "AssetResources": null
+  },
+  "Creatables": null,
+  "Hdr": {
+    "earn": 12595,
+    "fees": "A7NMWS3NT3IUDMLVO26ULGXGIIOUQ3ND2TXSER6EBGRZNOBOUIQXHIBGDE",
+    "frac": 3846799357,
+    "gen": "betanet-v1.0",
+    "gh": "mFgazF+2uRS1tMiL9dsj01hJGySEmPN28B/TjjvpVW0=",
+    "prev": "blk-U5MOD6WYEH2NOQZVY2G3M7OUMMBONJPEQDBAO55PWT6MASQ7AUPA",
+    "proto": "https://github.com/algorandfoundation/specs/tree/44fa607d6051730f5264526bf3c108d51f0eadb6",
+    "rnd": 22085518,
+    "rwcalr": 22500000,
+    "rwd": "7777777777777777777777777777777777777777777777777774MSJUVU",
+    "seed": "LM9PRjCcVDEGuUzI5BElS4RTn60x7pHZ0J3BRSgelOg=",
+    "spt": {
+      "0": {
+        "n": 22085632
+      }
+    },
+    "tc": 1337185754,
+    "ts": 1668439243,
+    "txn": "Le+J3oJwb/jumXXk8OGNBV5LtEjKApjFYw6hXRig11Q=",
+    "txn256": "oLF/IPwwlgXO6yaoGwW76m8vrYAZGzU6+ogpav4ecC8="
+  },
+  "KvMods": {
+    "bx:\u0000\u0000\u0000\u0000O\ufffd\ufffdibid_book": {
+      "Data": "AAAAAAAAADMAAAAAAAAAAQAAAAAAAABkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+      "OldData": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=="
+    }
+  },
+  "PrevTimestamp": 1668439239,
+  "StateProofNext": 0,
+  "Totals": {
+    "notpart": {
+      "mon": 1361656576290,
+      "rwd": 1361654
+    },
+    "offline": {
+      "mon": 112271490590529,
+      "rwd": 111623656
+    },
+    "online": {
+      "mon": 10011366852933181,
+      "rwd": 10010107336
+    },
+    "rwdlvl": 12595
+  },
+  "Txids": {
+    "/ebn/WznhB9/PukVYc9VuXai8Ox/nq5Tz4wgLqGyVIk=": {
+      "Intra": 0,
+      "LastValid": 22085521
+    },
+    "0NrGLcCMC+bT6amF8niax/GyZEsVRp/D+IoYL34egjE=": {
+      "Intra": 11,
+      "LastValid": 22085522
+    },
+    "1DkZwxxlE+CFMP2RNssJR9AcwRyWUgczLjQ65mGFV2Y=": {
+      "Intra": 78,
+      "LastValid": 22085522
+    },
+    "3XECD2JqkMntNIfSiOMxdct8CRTggME9xmKelnwHd+s=": {
+      "Intra": 44,
+      "LastValid": 22085522
+    },
+    "5Y98pZOuKlwXfb5jhZsEKECViuUXoqicIInjS4IbHS0=": {
+      "Intra": 5,
+      "LastValid": 22085522
+    },
+    "61Pq67EaDdxN3AVFvh4YnGQtLSEEpDEh2I7YNKU2u/Q=": {
+      "Intra": 2,
+      "LastValid": 22085521
+    },
+    "668VmAEt//2OH/twa4AT67FUJGigOU/xVVFNdOmUHxA=": {
+      "Intra": 29,
+      "LastValid": 22085522
+    },
+    "688VeaqyxL+lyyHrv4Abp4x2p28++15vUdwlhRXFmzY=": {
+      "Intra": 84,
+      "LastValid": 22085522
+    },
+    "6CNflytab/E/W7Z2HqJTfd4XTvqo81rXrpi4pTbUTpg=": {
+      "Intra": 81,
+      "LastValid": 22085522
+    },
+    "7dIoau5+szS4fcnAnSNRrsrTgVV16yvxgpiK4WDcAjQ=": {
+      "Intra": 16,
+      "LastValid": 22085522
+    },
+    "7iz6vIoesGkH+hINgd+hKsbSjgRRKsJ6Jh01iP8yngg=": {
+      "Intra": 25,
+      "LastValid": 22085522
+    },
+    "7tZGfRpdgPBELGlnPgnFOlbFfthwFyEazCvLcUElnr8=": {
+      "Intra": 4,
+      "LastValid": 22085522
+    },
+    "9+BqoBQ4ccmy0g2C3/vH55ym+neEiU8r4QoksjY8z0k=": {
+      "Intra": 52,
+      "LastValid": 22085522
+    },
+    "AGqLwibwxsU7eJk/RdHl4k3IN9D/dwv2psgp6b44fps=": {
+      "Intra": 19,
+      "LastValid": 22085522
+    },
+    "AjOo9IP/g2/oHLr4HedrblAHdvMCwTggTI2Tv8kKIXg=": {
+      "Intra": 26,
+      "LastValid": 22085522
+    },
+    "Cba6RSdSPuzqUhRfo9BXgX1Kb1Pd/qrHjqE64PcC4vA=": {
+      "Intra": 22,
+      "LastValid": 22085522
+    },
+    "DRAmeVanqdLSojiQdLG+oj93v4D9KIqpWpKD68n7qss=": {
+      "Intra": 36,
+      "LastValid": 22085522
+    },
+    "DTjlo2UV1wMKSKFk8jxK3IfWAVEYyRJW8ExS0LiGpPM=": {
+      "Intra": 88,
+      "LastValid": 22085522
+    },
+    "DrFIDoU2lpy/FEzTyBM1vL+3TSGIzhHjDtcc1ETlSnc=": {
+      "Intra": 40,
+      "LastValid": 22085522
+    },
+    "EqSuCBj/fYRGzUyvJXLSEDoqxJobo1Zz9m7+MR/uIDg=": {
+      "Intra": 66,
+      "LastValid": 22085522
+    },
+    "ExcKfw+4h1Yx/gQjy8m+6ZNXMBpfGkyr2T9h8tqx6Ag=": {
+      "Intra": 24,
+      "LastValid": 22085522
+    },
+    "FjJRVmf01CDjELIgnkooeggqsDaPr2yMIk5UhWfDnSQ=": {
+      "Intra": 46,
+      "LastValid": 22085522
+    },
+    "HO0ZzmTCdobn0TEL27A7MYYYLhe260ec+AcT5L+nQ14=": {
+      "Intra": 12,
+      "LastValid": 22085522
+    },
+    "HRP/RY/rizlGtfueu6yOeXZI2KPXARKBfmJhDDkBKSQ=": {
+      "Intra": 59,
+      "LastValid": 22085522
+    },
+    "HVZTdd+8sztzAbMK8r7BWgIJtMMa2/Sh1OX6PC+ygU4=": {
+      "Intra": 20,
+      "LastValid": 22085522
+    },
+    "IukS6BMxKelU8zoGIKqAUrom25A9zj06jS5LQ/dtosY=": {
+      "Intra": 76,
+      "LastValid": 22085522
+    },
+    "KsVfbK5XPz4s2Jfk0aaTkbYtgwowl5cAcM11sqXE9TA=": {
+      "Intra": 15,
+      "LastValid": 22085522
+    },
+    "L0Yh+EBPtrKheD8uKKv+pGkpMLG6kPwws2khonJ34KU=": {
+      "Intra": 65,
+      "LastValid": 22085522
+    },
+    "L2ASrQT2BvZHdOX+OMOzSohpLw7CZwPdbfXczNY2uw8=": {
+      "Intra": 33,
+      "LastValid": 22085522
+    },
+    "L7I0TLPSVW8owQlUNtFxqUTZbPM0x0aGTcJgHsEsOs4=": {
+      "Intra": 35,
+      "LastValid": 22085522
+    },
+    "LQjyHeb8dZI1u2EbQRLmwhUgzXEMmTH4cAr4eUrPwuc=": {
+      "Intra": 57,
+      "LastValid": 22085522
+    },
+    "LgxT9FxHQSHmTUxqQmivMLqoWp+SElwBeF44SrT8q58=": {
+      "Intra": 30,
+      "LastValid": 22085522
+    },
+    "LhXwPbZM1RZTYSOaLAUuzuyxlSxjhtLfH+1f/ivVZHc=": {
+      "Intra": 72,
+      "LastValid": 22085522
+    },
+    "LkIoZLEIpNGy06yejOZh+VmqaABQl9k78HI5GFTQliM=": {
+      "Intra": 87,
+      "LastValid": 22085522
+    },
+    "MFb+Lu11re+vPil5QPliG7zXzKpcGhSus1Qh2r98QCE=": {
+      "Intra": 37,
+      "LastValid": 22086516
+    },
+    "MPRb/Re/CW9S+CgP/WepMZwL2eliPvFCqPQrqGQGjnI=": {
+      "Intra": 68,
+      "LastValid": 22085522
+    },
+    "N1cstoK0FgkA90q4JzJVWqBhdVhWM9COIXtHLmo2NUQ=": {
+      "Intra": 18,
+      "LastValid": 22085522
+    },
+    "N2bqD6k/f8TKfwvAjhRJFahWAhNNLeZz8OCz9tf8YpQ=": {
+      "Intra": 7,
+      "LastValid": 22085522
+    },
+    "NP9FVuJWab/rST9nwzH5Nz9loC4o8c1SeR6LGNDCw4c=": {
+      "Intra": 74,
+      "LastValid": 22085522
+    },
+    "NdTN6SJqsm0tlZOopA43E3froYV+ZUqGXuZFnF3IdWU=": {
+      "Intra": 51,
+      "LastValid": 22085522
+    },
+    "O4nedQFp1KyluGQq4Axk9N4HuPpFliwdrldpAj7yhkI=": {
+      "Intra": 34,
+      "LastValid": 22085522
+    },
+    "Oc2lKbFRkVo55Y47L0bqdsuDTY0xdU/YDKcgK4QSqVo=": {
+      "Intra": 83,
+      "LastValid": 22085522
+    },
+    "PeOJiFLhCzHJEBmBT5yievoz3BqKvLBWPAri3vEzGKM=": {
+      "Intra": 6,
+      "LastValid": 22085522
+    },
+    "SGNxVVMPxSlQl9ez1W2aabSQs9C5qw9LobL+cA3l69U=": {
+      "Intra": 23,
+      "LastValid": 22085522
+    },
+    "SsfVcROk3RdEwIBaOTgYSs469REnLHQKK4zietFEhj4=": {
+      "Intra": 41,
+      "LastValid": 22085522
+    },
+    "U0KHHw/6/cfhCn9OGkD6Zm24Ct4yZFjB0nnK6o0bkGs=": {
+      "Intra": 42,
+      "LastValid": 22085522
+    },
+    "V9mUKaWcPfYeeldMD4TrhIvvXQz5641TFy4Jxd9vrHY=": {
+      "Intra": 45,
+      "LastValid": 22085522
+    },
+    "VNgwOgGuLjRQ5K+rdhY8B7aD6FHCcQPL+SezmURG9Wc=": {
+      "Intra": 27,
+      "LastValid": 22085522
+    },
+    "VtuOBkol9oykt6UCiVolk8nMtWJTcgfRq8tmii58PKA=": {
+      "Intra": 14,
+      "LastValid": 22085522
+    },
+    "WApfhQs1+FqpO/38uDxgAUqh0FIgwGfvuFRfQzw8Fzg=": {
+      "Intra": 62,
+      "LastValid": 22085522
+    },
+    "Ws77ikAeL5W+GonDPko/mES58XYf2yHyPReZCKQ9uSI=": {
+      "Intra": 70,
+      "LastValid": 22085522
+    },
+    "X01GkqlJDtTj8QOQf5Mb7KL3Xgxl4mB6Q5A5m9wNGzk=": {
+      "Intra": 3,
+      "LastValid": 22085522
+    },
+    "X85MQTvy8i8BwpoKcQvgccvpCIyJ7R3Wqf3CCIjC030=": {
+      "Intra": 17,
+      "LastValid": 22085522
+    },
+    "Xdtszxwvvz6nngLbA0arwuZRSkoNBDOiQvXJ+L6W7Tk=": {
+      "Intra": 61,
+      "LastValid": 22085522
+    },
+    "YQGOJbdoQdu/bX8+FNd2FhuYxnNs6kkoTGcRVQw/b2Y=": {
+      "Intra": 8,
+      "LastValid": 22085522
+    },
+    "YfZMnoPhiw1wmllQlcecV7WDk0/BGG1985JYkTU/FXM=": {
+      "Intra": 63,
+      "LastValid": 22085522
+    },
+    "ZkeHDjNv6DIuKAUpnq7AbbMh4WplWbSyVn5RiVbtzt8=": {
+      "Intra": 85,
+      "LastValid": 22085522
+    },
+    "avnv26a+7jdzEhxVhGtVlVG4lIhFlgVmRf9fkwwjbro=": {
+      "Intra": 56,
+      "LastValid": 22085522
+    },
+    "cHnD2UU9hOYn7j9BhvgqTTekDLt0oYlKEOCMiAh+Avo=": {
+      "Intra": 9,
+      "LastValid": 22085522
+    },
+    "cp+Du4w4OsZE+uZAcJnIeo0XSFceex1kAUSiKesZwD0=": {
+      "Intra": 53,
+      "LastValid": 22085522
+    },
+    "df0vtKmQ1KTG/2VOn+kQLR/bIfLVlm220Dp7Oxlkrew=": {
+      "Intra": 38,
+      "LastValid": 22085522
+    },
+    "eY4fUbiC0oSbXze8WAJq8lgWltxMhe1fFhTM1fHUMsg=": {
+      "Intra": 82,
+      "LastValid": 22085522
+    },
+    "etFswfkvHpwYFC8BdzLkC055ypFvf3h5DPeSgXHFpfM=": {
+      "Intra": 71,
+      "LastValid": 22085522
+    },
+    "fLBRCE01lujiQoWnUjeEEHm+9GYJevXKndz1+OG0+AE=": {
+      "Intra": 10,
+      "LastValid": 22085522
+    },
+    "frunmaLGjdoIVDxarVJoxVXfFkIvmmzZE/Eg3+Mx7cA=": {
+      "Intra": 89,
+      "LastValid": 22085522
+    },
+    "g+6qb0KFWvxeXXHbJLOoU3F/c/cVbEc0okJFVWX9yP4=": {
+      "Intra": 28,
+      "LastValid": 22085522
+    },
+    "g434l3G66Z8McmQXvqPBbU5gTUNa99t4+0lDbYX46wo=": {
+      "Intra": 75,
+      "LastValid": 22085522
+    },
+    "gGgA0VpJw/AjAVfZF6SHMsT/a3InAs/xOmX5mZ6uH8A=": {
+      "Intra": 43,
+      "LastValid": 22085522
+    },
+    "gJeFWNh3KVt3h5vxuWogfSXV80jGqL00L9Qxgu4z3D0=": {
+      "Intra": 1,
+      "LastValid": 22085521
+    },
+    "gtCjKVfinnP00QC6fgkvywD5W+/KEMHKpviRUECwr/o=": {
+      "Intra": 80,
+      "LastValid": 22085522
+    },
+    "hiQprUGff2FK1mfl0MAx06cq7UC+GRtlY0qsFUYr3yk=": {
+      "Intra": 58,
+      "LastValid": 22085522
+    },
+    "iAEPzk9QX6PNEQVlTYF+iObWH0BgjyEzIHcjRqm9yrI=": {
+      "Intra": 86,
+      "LastValid": 22085522
+    },
+    "iccf4oBq78YUqL5PlJA6r1T4c5uvmHZrRAeucoWz/Qc=": {
+      "Intra": 54,
+      "LastValid": 22085522
+    },
+    "ipOyvbFzXhaT1SllbqWFFmsa4Nji+0MouDhHqWz4BAg=": {
+      "Intra": 13,
+      "LastValid": 22085522
+    },
+    "jEu5H3f/WGthnutL3P6olbq5sHq8dHyJ+HEPoIikreI=": {
+      "Intra": 32,
+      "LastValid": 22085522
+    },
+    "kNVU517vJDuK8WJFJAl9Jfro5zlQ+8JOQnlmNTQv8Js=": {
+      "Intra": 73,
+      "LastValid": 22085522
+    },
+    "kkPFrf22vZVOip/ar6EanQUNRiEaKCHG1UXXafjnLNY=": {
+      "Intra": 48,
+      "LastValid": 22085522
+    },
+    "lN/6qCEOpUPinJFaE5kO8mWHlhYDfNrJDL2LwBapees=": {
+      "Intra": 79,
+      "LastValid": 22085522
+    },
+    "mh27/yJsZPc8d/PPaY8nuX44NqoLycJgocfFTE3P3ek=": {
+      "Intra": 77,
+      "LastValid": 22085522
+    },
+    "o/hQmuYgt8E6++O+qoZihko1aJmNYEBxFawmfT/4M/4=": {
+      "Intra": 21,
+      "LastValid": 22085522
+    },
+    "oCmlC9QMwbzRSK/H+gfc3XGQaGoeZBOTCfF7sFUBHxo=": {
+      "Intra": 64,
+      "LastValid": 22085522
+    },
+    "ojLZAjkbbdk8SA3eX/ZKpBqaHD0X2RmTMK3p/AvThxk=": {
+      "Intra": 39,
+      "LastValid": 22085522
+    },
+    "pOKA0Dl26fy1muNefh4Sx9HCvpJ4jiyCUdUCiEqTnXk=": {
+      "Intra": 47,
+      "LastValid": 22085522
+    },
+    "s/fd6vfMtm+YCAhaoHENcBwBRd1ENKlQsKUPHPIQcnc=": {
+      "Intra": 91,
+      "LastValid": 22085522
+    },
+    "sBk6QQcIlnuknZ2rgEtKcoQOsjq8ePQpcTjsR9/BBJc=": {
+      "Intra": 49,
+      "LastValid": 22085522
+    },
+    "sv9CIGY47gaxnQh3d7tPhiKRh3wXzKxioBamJxYgwvM=": {
+      "Intra": 55,
+      "LastValid": 22085522
+    },
+    "tli8tsKY68hryTj1iWCZUYncjnNfUz1oLpncEONrMMU=": {
+      "Intra": 60,
+      "LastValid": 22085522
+    },
+    "wgUj7G+pLhNkIZwWwIqkCOJ1mI6b9RqAEfZCjbZAaUY=": {
+      "Intra": 31,
+      "LastValid": 22085522
+    },
+    "whHkzq7nHg52xRu+g/zcm9qv9QGVRd7a/S9ppsvssDE=": {
+      "Intra": 67,
+      "LastValid": 22085522
+    },
+    "xN6l0I+1rrATstQlZ9/FKKIbF6UZdw2VncuB1NID/PU=": {
+      "Intra": 90,
+      "LastValid": 22085522
+    },
+    "yrd/0F9SrLribIy5ZzxxT34SN8DhCaFgYfTxw/OBFnU=": {
+      "Intra": 69,
+      "LastValid": 22085522
+    },
+    "z6F4wlkERBSJCR8MndO9cCtLZikNPXwGs322ms033qA=": {
+      "Intra": 50,
+      "LastValid": 22085522
+    }
+  },
+  "Txleases": null
+}

--- a/features/resources/v2algodclient_responsejsons/statedelta_testnet_26091000.json
+++ b/features/resources/v2algodclient_responsejsons/statedelta_testnet_26091000.json
@@ -1,0 +1,570 @@
+{
+  "Accts": {
+    "Accts": [
+      {
+        "Addr": "7777777777777777777777777777777777777777777777777774MSJUVU",
+        "AuthAddr": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ",
+        "MicroAlgos": 2051818321,
+        "RewardedMicroAlgos": 0,
+        "RewardsBase": 0,
+        "SelectionID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "StateProofID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "Status": 2,
+        "TotalAppLocalStates": 0,
+        "TotalAppParams": 0,
+        "TotalAppSchema": {},
+        "TotalAssetParams": 0,
+        "TotalAssets": 0,
+        "TotalBoxBytes": 0,
+        "TotalBoxes": 0,
+        "TotalExtraAppPages": 0,
+        "VoteFirstValid": 0,
+        "VoteID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "VoteKeyDilution": 0,
+        "VoteLastValid": 0
+      },
+      {
+        "Addr": "6DJL462RP2DWBGMJIPDQ5PJCXRJKI34Z4GRWB3MEPAGRBAPTBL7U42RDYI",
+        "AuthAddr": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ",
+        "MicroAlgos": 550506000,
+        "RewardedMicroAlgos": 0,
+        "RewardsBase": 27521,
+        "SelectionID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "StateProofID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "Status": 0,
+        "TotalAppLocalStates": 0,
+        "TotalAppParams": 0,
+        "TotalAppSchema": {},
+        "TotalAssetParams": 0,
+        "TotalAssets": 0,
+        "TotalBoxBytes": 0,
+        "TotalBoxes": 0,
+        "TotalExtraAppPages": 0,
+        "VoteFirstValid": 0,
+        "VoteID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "VoteKeyDilution": 0,
+        "VoteLastValid": 0
+      },
+      {
+        "Addr": "A7NMWS3NT3IUDMLVO26ULGXGIIOUQ3ND2TXSER6EBGRZNOBOUIQXHIBGDE",
+        "AuthAddr": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ",
+        "MicroAlgos": 342106532750,
+        "RewardedMicroAlgos": 0,
+        "RewardsBase": 0,
+        "SelectionID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "StateProofID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "Status": 2,
+        "TotalAppLocalStates": 0,
+        "TotalAppParams": 0,
+        "TotalAppSchema": {},
+        "TotalAssetParams": 0,
+        "TotalAssets": 0,
+        "TotalBoxBytes": 0,
+        "TotalBoxes": 0,
+        "TotalExtraAppPages": 0,
+        "VoteFirstValid": 0,
+        "VoteID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "VoteKeyDilution": 0,
+        "VoteLastValid": 0
+      },
+      {
+        "Addr": "XRLMBT6LVVV22E35CRT5TFQKGQPQ4EE6X6K4U3XPQ3UOCRY5FYY7BFEBJE",
+        "AuthAddr": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ",
+        "MicroAlgos": 190692000,
+        "RewardedMicroAlgos": 0,
+        "RewardsBase": 27521,
+        "SelectionID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "StateProofID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "Status": 0,
+        "TotalAppLocalStates": 17,
+        "TotalAppParams": 13,
+        "TotalAppSchema": {
+          "nbs": 80,
+          "nui": 221
+        },
+        "TotalAssetParams": 2,
+        "TotalAssets": 2,
+        "TotalBoxBytes": 0,
+        "TotalBoxes": 0,
+        "TotalExtraAppPages": 0,
+        "VoteFirstValid": 0,
+        "VoteID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "VoteKeyDilution": 0,
+        "VoteLastValid": 0
+      },
+      {
+        "Addr": "OOADCJDVTA3QKWLBI7QBQZVTXXOVNYY4RMXNLAQNPQGTNK7Y446SX5MFCM",
+        "AuthAddr": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ",
+        "MicroAlgos": 39927000,
+        "RewardedMicroAlgos": 0,
+        "RewardsBase": 27521,
+        "SelectionID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "StateProofID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "Status": 0,
+        "TotalAppLocalStates": 1,
+        "TotalAppParams": 0,
+        "TotalAppSchema": {
+          "nbs": 16
+        },
+        "TotalAssetParams": 0,
+        "TotalAssets": 1,
+        "TotalBoxBytes": 0,
+        "TotalBoxes": 0,
+        "TotalExtraAppPages": 0,
+        "VoteFirstValid": 0,
+        "VoteID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "VoteKeyDilution": 0,
+        "VoteLastValid": 0
+      }
+    ],
+    "AppResources": [
+      {
+        "Addr": "ZOAAQIADWSKRAM3VP4QUBOCHAN34JSR45KGYY5KJ3JMB6D5OCLJ2HF6DN4",
+        "Aidx": 96279902,
+        "Params": {
+          "Deleted": false,
+          "Params": null
+        },
+        "State": {
+          "Deleted": false,
+          "LocalState": {
+            "hsch": {
+              "nbs": 16
+            },
+            "tkv": {
+              "\f": {
+                "tb": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+                "tt": 1
+              },
+              "\r": {
+                "tb": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0002\ufffd\ufffdS\u0000\u0000\u0000\u0000\u0000\u0000\u0003R\u0000\u0000\u0000\u0002$\ufffd\ufffd 07\u0000\u0000\u0000\u0000\u0000\u0001\ufffd\u0005S\u0000\u0000\u0000\u0000\u0000\u0000\u0003p\u0000\u0000\u0000\u0000\ufffd\u001e\u001b\ufffd08",
+                "tt": 1
+              },
+              "\u000e": {
+                "tb": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001E\u0015B\u0000\u0000\u0000\u0000\u0000\u0000\u0000d\u0000\u0000\u0000\u0004\ufffd\u0017\ufffd\u00000;\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+                "tt": 1
+              },
+              "accountInfo": {
+                "tb": "\u0000\u0000\u0000\u0000\u00003\u0014\ufffd\u0000\u0000\u0000\u0000\u0000\ufffdo\ufffd\u0000\u0000\u0000\u0003\u001d\ufffd\ufffd\u0000\u0000\u0000\u0000\u0001\ufffd\ufffdk \u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u000b?\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd",
+                "tt": 1
+              }
+            }
+          }
+        }
+      },
+      {
+        "Addr": "7SWZ6PM2TWU2RL2SYV2SNWPEM67LUCE67XGUIKG6RWSZEBDCAEWYUHQIQM",
+        "Aidx": 96279902,
+        "Params": {
+          "Deleted": false,
+          "Params": null
+        },
+        "State": {
+          "Deleted": false,
+          "LocalState": {
+            "hsch": {
+              "nbs": 16
+            },
+            "tkv": {
+              "\u000e": {
+                "tb": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+                "tt": 1
+              },
+              "accountInfo": {
+                "tb": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001O\ufffd\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u001e\ufffd\ufffd\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u000f\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd",
+                "tt": 1
+              }
+            }
+          }
+        }
+      },
+      {
+        "Addr": "PA5BLCW7U4SMDUIPXNY7HUIZIDI6L6ZW7NZKPT4DUJQN6E5UCBAAHKNZLU",
+        "Aidx": 92138200,
+        "Params": {
+          "Deleted": false,
+          "Params": null
+        },
+        "State": {
+          "Deleted": false,
+          "LocalState": {
+            "hsch": {
+              "nbs": 16
+            },
+            "tkv": {
+              "\u000e": {
+                "tb": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0004f\ufffdB\u0000\u0000\u0000\u0000\u0000\u0000\u0014Z\u0000\u0000\u0000\u0000\u0000\u000fB@P<",
+                "tt": 1
+              },
+              "accountInfo": {
+                "tb": "\u0000\u0000\u0000\u0000\u0000\u0000\u0014Z\u0000\u0000\u0000\u0000\u0000\u0000[\ufffd\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u000fB@\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0007\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd",
+                "tt": 1
+              }
+            }
+          }
+        }
+      },
+      {
+        "Addr": "KHKO4BLTFEHRXECEGCPRYOEHFZQVYAFOQSV5O2XUHQ7HHDKKZ7OZNQEEAA",
+        "Aidx": 92138200,
+        "Params": {
+          "Deleted": false,
+          "Params": null
+        },
+        "State": {
+          "Deleted": false,
+          "LocalState": {
+            "hsch": {
+              "nbs": 16
+            },
+            "tkv": {
+              "\u000e": {
+                "tb": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0004\ufffd\ufffdS\u0000\u0000\u0000\u0000\u0000\u0000\"\ufffd\u0000\u0000\u0000\u00009\u0019\ufffd\ufffd0<",
+                "tt": 1
+              },
+              "accountInfo": {
+                "tb": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\ufffd\tr\u0000\u0000\u0000\u00009\u0019\ufffd\ufffd\u0000\u0000\u0000\u0000X\ufffd_@\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0007\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd",
+                "tt": 1
+              }
+            }
+          }
+        }
+      },
+      {
+        "Addr": "2MXD4RPX4TE3LGWU3TVQKYDPL56A4P2ENHPZFOKS6HV3VGIKFFZVLXMQ3E",
+        "Aidx": 106421217,
+        "Params": {
+          "Deleted": false,
+          "Params": {
+            "approv": "BSALAQACBQYECRsUwIQ9AyYWA0dPVgtGTFBfQkFMQU5DRQtVU0RGX1NVUFBMWRNMQVNUX1BSSUNFX1NFVF9USU1FCkZMUF9TVVBQTFkSU1RBS0VEX0ZMUF9UUkFDS0VSD0ZFRV9GTFBfVFJBQ0tFUgxWQVVMVF9BUFBfSUQNTEFTVF9BRERFRF9BVBFDT09MRE9XTl9EVVJBVElPTg1NSU5fRkxQX1BSSUNFElBSRVZfTUlOX0ZMUF9QUklDRQ1NQVhfRkxQX1BSSUNFElBSRVZfTUFYX0ZMUF9QUklDRQ9NQVhfRkxQX0JBTEFOQ0UHdW5zdGFrZQVzdGFrZQxWQVVMVF9FU0NST1cMQVVNX0FERElUSU9ODUFVTV9ERURVQ1RJT04KSVNfSEFORExFUg9JTl9QUklWQVRFX01PREUxGCMSQAV7MRkiEkAFYTEZJBJABVExGSEFEkAFQTEZJRJABTI2GgCABnNldEdvdhJABQw2GgCAEHNldEluUHJpdmF0ZU1vZGUSQATfNhoAgApzZXRIYW5kbGVyEkAEsDYaAIATc2V0Q29vbGRvd25EdXJhdGlvbhJABHY2GgCAEHNldEF1bUFkanVzdG1lbnQSQARBNhoAgA5zZXRWYXVsdEVzY3JvdxJABBI2GgCAC3NldFRyYWNrZXJzEkAD4DYaAIAQc2V0TWF4RmxwQmFsYW5jZRJAA7M2GgCADXNldFVzZGZTdXBwbHkSQAOKNhoAgAtzZXRGbHBQcmljZRJAAy42GgCADGFkZExpcXVpZGl0eRJAAWU2GgCAD3JlbW92ZUxpcXVpZGl0eRJAAAEAMgQhBg9EMRYlCTgQIQQSMRYlCTgZIxIQMRYlCTkaACcPEhAxFiUJOBgnBWQSEDEWJQk5GgEXNhoBFxIQRDEWJAk4ECEEEjEWJAk4GSMSEDEWJAk5GgAnDxIQMRYkCTgYJwZkEhAxFiQJORoBFzYaARcSEEQxFiIIOBAhBBIxFiIIOBkjEhAxFiIIORoAgAhzZWxsVXNkZhIQMRYiCDgYJwdkEhAxFiIIORoBFzYaAxcSEEQxGyEFEjYaARcjDRA2GgEXMQApYg4QRDEAJwhiJwlkCDIGDEQrZDIGIQcJDUQ2GgIXJwpkEicLZCMNK2QyBiEICQ0QNhoCFycLZBIQEUQ2GgEXNhoCFx0jIQkfSEhMFEQ1CTQJNhoDFxJENAkqZA1AACEqKmQ0CQlnMQApMQApYjYaARcJZicEJwRkNhoBFwlnIkMqI2dC/+A2MgKAD0lTX1NXQVBfRU5BQkxFRGU1AzUENjICgBNJU19MRVZFUkFHRV9FTkFCTEVEZTUFNQY0BDQGEEQyBCEGD0QxFiIJOBAhBBIxFiIJOBkjEhAxFiIJORoAgAdidXlVc2RmEhAxFiIJOBg2MgESEDEWIgk5MAA2MAASEDEWIgk5GgQXNhoBFxIQRDEWJAg4ECEEEjEWJAg4GSMSEDEWJAg5GgAnEBIQMRYkCDgYJwZkEhAxFiQIORoBFzYaAxcSEEQxFiUIOBAhBBIxFiUIOBkjEhAxFiUIORoAJxASEDEWJQg4GCcFZBIQMRYlCDkaARc2GgMXEhBEMRslEjEzJBIQNjICJwdkEhAxMSISEEQxFiINMRYyBCEECQwQRDYyAjYaBGU1BzUINAg2MgESRCoqZDYaARcIZytkMgYhBwkNRDYaAhcnDGQSJw1kIw0rZDIGIQgJDRA2GgIXJw1kEhARRDYaARchCR0jNhoCFx9ISEwURDUCNAI2GgMXEkQnDmQjDUAAHTEAKTEAKWI0AghmJwQnBGQ0AghnMQAnCDIGZiJDJw5kMQApYjQCCA9EQv/UNjIBgA1JTkZPX1BST1ZJREVSZTUANQExADQBEkQxGyEKEjEzIhIQRCcNJwxkZycMNhoBF2cnCycKZGcnCjYaAhdnKzIGZyJDMQAoZBJEMRskEkQqNhoBF2ciQzEAKGQSRDEbJBJEJw42GgEXZyJDMQAoZBJEMRsiEkQxMyQSRCcGNjIBZycFNjICZyJDMQAoZBJEMRsiEkQxHSISRCcRNhwBZyJDMQAoZBJEMRshChJEJxI2GgEXZycTNhoCF2ciQzEAKGQSRDEbJBJENhoBF4GArAIORCcJNhoBF2ciQzEAKGQSRDEbJBJEMR0iEkQ2HAEnFDYaARdmIkMxAChkEkQxGyQSRCcVNhoBF2ciQzEAKGQSRDEbIhJEMR0iEkQoNhwBZyJDMQAoZBJEIkMxAChkEkQiQzEAKWIjEkQiQzEAKSNmMQAnFCNmMQAnCCNmIkMxGyEFEkQxMSMSRDEdIhJEMTMiEkQoMQBnJwc2MgFnJwYjZycFI2cnETYcAWcnCTYaABdnJxI2GgEXZycTNhoCF2cnFTYaAxdnKiNnJwQjZyJD",
+            "clearp": "BYEBQw==",
+            "epp": 1,
+            "gs": {
+              "AUM_ADDITION": {
+                "tt": 2
+              },
+              "AUM_DEDUCTION": {
+                "tt": 2
+              },
+              "COOLDOWN_DURATION": {
+                "tt": 2,
+                "ui": 200
+              },
+              "FEE_FLP_TRACKER": {
+                "tt": 2,
+                "ui": 106421532
+              },
+              "FLP_SUPPLY": {
+                "tt": 2,
+                "ui": 478261977612
+              },
+              "GOV": {
+                "tb": "\ufffd.>E\ufffd\ufffdɵ\ufffd\ufffd\ufffd\ufffd\u0005`o_|\u000e?Diߒ\ufffdR\ufffd뺙\n)s",
+                "tt": 1
+              },
+              "IN_PRIVATE_MODE": {
+                "tt": 2,
+                "ui": 1
+              },
+              "LAST_PRICE_SET_TIME": {
+                "tt": 2,
+                "ui": 26910000
+              },
+              "MAX_FLP_PRICE": {
+                "tt": 2,
+                "ui": 815688
+              },
+              "MIN_FLP_PRICE": {
+                "tt": 2,
+                "ui": 814949
+              },
+              "PREV_MAX_FLP_PRICE": {
+                "tt": 2,
+                "ui": 815688
+              },
+              "PREV_MIN_FLP_PRICE": {
+                "tt": 2,
+                "ui": 814949
+              },
+              "STAKED_FLP_TRACKER": {
+                "tt": 2,
+                "ui": 106421501
+              },
+              "USDF_SUPPLY": {
+                "tt": 2,
+                "ui": 473292517864
+              },
+              "VAULT_APP_ID": {
+                "tt": 2,
+                "ui": 106418092
+              },
+              "VAULT_ESCROW": {
+                "tb": "\ufffd\ufffd\ufffd`\ufffd\u001dʷ\u0019Ϻ)\"TpY(}m\ufffd\u0010\u0018\ufffd\ufffd\ufffdK\u001eZ8\u001f\ufffd^",
+                "tt": 1
+              }
+            },
+            "gsch": {
+              "nbs": 10,
+              "nui": 25
+            },
+            "lsch": {
+              "nbs": 3,
+              "nui": 7
+            }
+          }
+        },
+        "State": {
+          "Deleted": false,
+          "LocalState": null
+        }
+      },
+      {
+        "Addr": "OOADCJDVTA3QKWLBI7QBQZVTXXOVNYY4RMXNLAQNPQGTNK7Y446SX5MFCM",
+        "Aidx": 92138200,
+        "Params": {
+          "Deleted": false,
+          "Params": null
+        },
+        "State": {
+          "Deleted": false,
+          "LocalState": {
+            "hsch": {
+              "nbs": 16
+            },
+            "tkv": {
+              "\f": {
+                "tb": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+                "tt": 1
+              },
+              "\r": {
+                "tb": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+                "tt": 1
+              },
+              "\u000e": {
+                "tb": "\u0000\u0000\u0000\u0000\u0000\u0004\f/S\u0000\u0000\u0000\u0000\u0000\u0000$\ufffd\u0000\u0000\u0000\u0000\u0000\u000fB@P9\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0003\ufffdIS\u0000\u0000\u0000\u0000\u0000\u0000)\u000e\u0000\u0000\u0000\u0000\u0000\u000fB@P;\u0000\u0000\u0000\u0000\u0000\u0004\ufffd\ufffdB\u0000\u0000\u0000\u0000\u0000\u0000\"\ufffd\u0000\u0000\u0000\u0000\u0000\u000fB@M<",
+                "tt": 1
+              },
+              "accountInfo": {
+                "tb": "\u0000\u0000\u0000\u0000\u0000\u0000\"\ufffd\u0000\u0000\u0000\u0000\u0000\u0001\ufffd\ufffd\u0000\u0000\u0000\u0000\u0000\u001e\ufffd\ufffd\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0002\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd",
+                "tt": 1
+              }
+            }
+          }
+        }
+      },
+      {
+        "Addr": "43ZZTEATZRBQVH3JLVLQ3OL5WLC7F2SN7G26EHZ3ELD2B7RRYCR2GTHJ7E",
+        "Aidx": 92138200,
+        "Params": {
+          "Deleted": false,
+          "Params": {
+            "approv": "BiAQAAEbBAgQGEBIUAoJEZBOAgwmGgthY2NvdW50SW5mbwFNAVMWQkFTRV9DVVJSRU5DWV9ERUNJTUFMUwFCEVBSSUNFX0NVUlJFTkNZX0lEAVAMc3RvcmFnZV9mdWxsEEJBU0VfQ1VSUkVOQ1lfSUQDQ1JBA01UTgNCS0EBMAFUDU9SREVSX0NPVU5URVILTUZFRV9USUVSXzELVEZFRV9USUVSXzEMTUlOX1NJWkVfSU5DDk1JTl9PUkRFUl9TSVpFDU1JTl9QUklDRV9JTkMEUEFJUg1CQVNFX0NVUlJFTkNZDlBSSUNFX0NVUlJFTkNZCHdpdGhkcmF3AUkPYWNjb3VudF9jb3VudGVyMRgiEkAUpDEZIxJAFEoxGSEOEkATCDEZJRJAEvoxGYEFEkAS6zEZIhJAAAEAMRsiEkAS2jYaAIALYXNzZXRfb3B0aW4SQBKsNhoAgAdzZXRfYmthEkASjTYaAIAKc2V0X2dsb2JhbBJAEkk2GgCACnVwZGF0ZV9tdG4SQBIONhoAJxcSQBFCNhoAgAluZXdfb3JkZXISQA3lNhoAgAxtYXRjaF9vcmRlcnMSQASqNhoAgAx1bmZpbGxfb3JkZXISQAGwNhoAgAxjYW5jZWxfb3JkZXISQAAHI0AAAQAjQycKZCISRDEAKGI1zDTMIls1wzTMIQRbNcQ0zCEFWzXFNMwhBls1xjTMVyAgNcc0zCEHWzXINMwhCFs1yTTMIQlbNco2GgIXIwklCjXOMQAiNM4WVwcBYzXQNc800EAAAiJDNM8kNhoCFzTOJQsJIwkLJFg1zTTNIls1vTTNVwgBNb40zSELWzW/NM0hDFs1wDTNVxkBNcE2GgIXNcI2GgEXNL0SRDS+KhJAANM0vicEEkAArSJDNMIjCSUKNdM00xZXBwE11CQ0wjTTJQsJIwkLNdExACI01GM11jXVNNZAAHglJAuvNdIxADTUNNIiNNFSJK9QNNI00SQIJSQLUlBmNMo2GgIXIwkjVDXKNMMWNMQWUDTFFlA0xhZQNMdQNMgWUDTJFlA0yhZQNdczAAAoNNdmgAtjYW5jZWxPcmRlcrA2GgEXFrA0xhawNMUWsDTEFrA0wxawI0M01TXSQv+HNMA0vwshCitklAo1yzTENMsINcQ0wzTLCTXDQv83NMA1yzTGNMsINcY0xTTLCTXFQv8iMQAnC2QSRDYcATWoNKgoYjWrNKsiWzWgNKshBFs1oTSrIQVbNaI0qyEGWzWjNKtXICA1pDSrIQdbNaU0qyEIWzWmNKshCVs1pzYaAhcjCSUKNa00qCI0rRZXBwFjNa81rjSvQAACIkM0riQ2GgIXNK0lCwkjCQskWDWsNKwiWzWZNKxXCAE1mjSsIQtbNZs0rCEMWzWcNKxXGQE1nTYaAhc1njSZNhoBFxJENhoDFyINRDSdKRI0micEEhBAAh8iNao0nScYEkACCTSdKRJAAeU0nScGEkAB0iJDNJoqEkABsjSaJwQSQAF6IkM0qjYaAxcSNKoiEjScNhoDFxIQEUABAjSqIhIUQADuNJw2GgMXCTWcNJ4iEkAAzTSeIwklCjW4NLgWVwcBNbkkNJ40uCULCSMJCzW2NKgiNLljNbs1ujS7QACaJSQLrzW3NKg0uTS3IjS2UjSZFjSaUDSbFlA0nBZQNJ1QNJ4WVwcBUFA0tzS2JAglJAtSUGY0njSeIwkiVDWfNKAWNKEWUDSiFlA0oxZQNKRQNKUWUDSmFlA0pxZQNbw0qCg0vGaAC3VuZmlsbE9yZGVysDYaARcWsDSjFrA0ohawNKEWsDSgFrA2GgMXFrA0qLA2GgQXFrAjQzS6NbdC/2U0npM1njSeIhJB/ycnB7AiQzSbNhoDFwk1m0L/DzSeIwklCjWyNLIWVwcBNbMkNJ40siULCSMJCzWwNKgiNLNjNbU1tDS1QAAsJSQLrzWxNKg0szSxIjSwUiSvUDSxNLAkCCUkC1JQZjSnNJ4jCSNUNadC/yk0tDWxQv/TNJ0pEkAAIDYaAxc0mwshCitklAo1qTShNKkINaE0oDSpCTWgQv5hNhoDFzWpQv/mNhoDFzWpNKM0qQg1ozSiNKkJNaJC/kE0nDYaAxcSREL+JTSaKhJAAAs0qjYaAxcPREL+EzScNhoDFw9EQv4INJw2GgMXD0RC/f00mzWqQv3dMQAnC2QSRDYaBRciDUQ2GgIXIwklCjVWNhwBIjRWFlcHAWM1WDVXNFhAAAIiQzRXJDYaAhc0ViULCSMJCyRYNVU0VSJbNTM0VVcIATU0NFUhC1s1NTRVIQxbNTY0VVcZATU3NhoCFzU4NDQqEkAHwjYcATVRNhwBKGI1XzRfIls1PDRfIQRbNT00XyEFWzU+NF8hBls1PzRfVyAgNUA0XyEHWzVBNF8hCFs1QjRfIQlbNUM0MzVENDQ1RTQ1NUY0NjVHNDc1SDQ4NUk2HAI1UjYcAihiNWA0YCJbNSs0YCEEWzUsNGAhBVs1LTRgIQZbNS40YFcgIDUvNGAhB1s1MDRgIQhbNTE0YCEJWzUyNhoEFyMJJQo1YjYcAiI0YhZXBwFjNWQ1YzRkQAACIkM0YyQ2GgQXNGIlCwkjCQskWDVhNGEiWzUzNGFXCAE1NDRhIQtbNTU0YSEMWzU2NGFXGQE1NzYaBBc1ODRENhoBFxI0MzYaAxcSEEQ0RTQ0EhRENEQ0MwxABok0NycMEjQ3JwYSEUQ0SCcGEhREJw01Syk1OjQ1NU80SCkSQAZdIjVNNFE0UhJAA3Y2GgUXNE8LIQorZJQKNU40SCkSQANKNEY0NQ9ENEc2GgUXDzQ2NhoFFw8QRDRIKRJAAyc0RjYaBRcLIQorZJQKNE4JNVA0SycNEkAC8jYaBRchDQonD2QLNUw0TiENCicQZAs1OzQ9NFAINT00PDRONFAICTU8ND82GgUXCDU/NCw0Tgg1LDQtNhoFFwk1LTRIKRIUNEc2GgUXEhA0TTROEhFAAjs0TSISFEACKTRHNhoFFwk1RzRJIhJAAgg0SSMJJQo1hzSHFlcHATWIJDRJNIclCwkjCQs1hTRRIjSIYzWKNYk0ikAB1SUkC681hjRRNIg0hiI0hVI0RBY0RVA0RhZQNEcWUDRIUDRJFlcHAVBQNIY0hSQIJSQLUlBmNEk0SSMJIlQ1SjYaBRc0NhJAAS00NjYaBRcJNTY0OCISQAEMNDgjCSUKNZM0kxZXBwE1lCQ0ODSTJQsJIwkLNZE0UiI0lGM1ljWVNJZAANklJAuvNZI0UjSUNJIiNJFSNDMWNDRQNDUWUDQ2FlA0N1A0OBZXBwFQUDSSNJEkCCUkC1JQZjQ4NDgjCSJUNTk0PBY0PRZQND4WUDQ/FlA0QFA0QRZQNEIWUDRDFlA1lzRRKDSXZjQrFjQsFlA0LRZQNC4WUDQvUDQwFlA0MRZQNDIWUDWYNFIoNJhmgAttYXRjaF9vcmRlcrA2GgYXFrA0RBawNDMWsDRPFrA2GgUXFrA0UbA0PRawNDwWsDQ/FrA0PhawNFKwNCwWsDQrFrA0LhawNC0WsCNDNJU1kkL/JjQ4kzU4NDgiEkH+6CcHsCJDNDI0OCMJI1Q1MjQ4IwklCjWNNI0WVwcBNY4kNDg0jSULCSMJCzWLNFIiNI5jNZA1jzSQQAAiJSQLrzWMNFI0jjSMIjSLUiSvUDSMNIskCCUkC1JQZkL+9jSPNYxC/900iTWGQv4qNEmTNUk0SSISQf3sJwewIkM0TTROCTVGQv3WNEM0SSMJI1Q1QzRJIwklCjWBNIEWVwcBNYIkNEk0gSULCSMJCzV/NFEiNIJjNYQ1gzSEQAAiJSQLrzWANFE0gjSAIjR/UiSvUDSANH8kCCUkC1JQZkL98DSDNYBC/902GgUXIQ0KJxBkCzVMNE4hDQonD2QLNTtC/QsiNVBC/OU0TTROD0Q0RyIPNDY2GgUXDxBEQvy2NEsnDRJAAV00MzVUNDY2GgUXCTU2NhoFFzVTNC00Uwk1LTQuNFMINS40NiISQADWNDgiEkAAvjQ4IwklCjV6NHoWVwcBNXskNDg0eiULCSMJCzV4NFIiNHtjNX01fDR9QACLJSQLrzV5NFI0ezR5IjR4UjQzFjQ0UDQ1FlA0NhZQNDdQNDgWVwcBUFA0eTR4JAglJAtSUGY0ODQ4IwkiVDU5NCsWNCwWUDQtFlA0LhZQNC9QNDAWUDQxFlA0MhZQNX40Uig0fmaACnNlbGZfdHJhZGWwNFQWsDRSsDQuFrA0LRawND0WsDQ8FrAjQzR8NXlC/3Q0OJM1ODQ4IhJB/zYnB7AiQzQyNDgjCSNUNTI0OCMJJQo1dDR0FlcHATV1JDQ4NHQlCwkjCQs1cjRSIjR1YzV3NXY0d0AAIiUkC681czRSNHU0cyI0clIkr1A0czRyJAglJAtSUGZC/0Q0djVzQv/dNEQ1VDRIKRJAAWM0RjYaBRcLIQorZJQKNVM0PDRTCTU8ND00Uwg1PTRIKRIUNEc2GgUXEhA0TTYaBRcSEUAAzzRIKRJAALw0RzYaBRcJNUc0SSISQACbNEkjCSUKNW00bRZXBwE1biQ0STRtJQsJIwkLNWs0USI0bmM1cDVvNHBAAGglJAuvNWw0UTRuNGwiNGtSNEQWNEVQNEYWUDRHFlA0SFA0SRZXBwFQUDRsNGskCCUkC1JQZjRJNEkjCSJUNUo0PBY0PRZQND4WUDQ/FlA0QFA0QRZQNEIWUDRDFlA1cTRRKDRxZkL+eDRvNWxC/5c0SZM1STRJIhJB/1knB7AiQzRGNhoFFwk1RkL/QTRDNEkjCSNUNUM0SSMJJQo1ZzRnFlcHATVoJDRJNGclCwkjCQs1ZTRRIjRoYzVqNWk0akAAIiUkC681ZjRRNGg0ZiI0ZVIkr1A0ZjRlJAglJAtSUGZC/1s0aTVmQv/dNhoFFzVTQv6jNEY1TUL5nzRIJwwSNEgnBhIRRDQ3JwYSFEQpNUsnDTU6NEY1T0L5dDYcATVSNhwBKGI1WTRZIls1KzRZIQRbNSw0WSEFWzUtNFkhBls1LjRZVyAgNS80WSEHWzUwNFkhCFs1MTRZIQlbNTI2HAI1UTYcAihiNVo0WiJbNTw0WiEEWzU9NFohBVs1PjRaIQZbNT80WlcgIDVANFohB1s1QTRaIQhbNUI0WiEJWzVDNhoEFyMJJQo1XDYcAiI0XBZXBwFjNV41XTReQAACIkM0XSQ2GgQXNFwlCwkjCQskWDVbNFsiWzVENFtXCAE1RTRbIQtbNUY0WyEMWzVHNFtXGQE1SDYaBBc1STRENhoDFxI0MzYaARcSEERC+FMnCmQiEkQ2GgEnBBI2GgEqEhFENhoEJwwSNhoEJwYSETYaBCcYEhE2GgQpEhFENhoEKRI2GgEqEhBAAuo2GgQpEjYaAScEEhA2GgMXIhIQQAK/NhoCFyINNhoDFyINEEQ2GgMXJxFkGCISNhoDFycSZA8QNhoCFycTZBgiEhBEIjUgIjUhJww1IjEAKGI1IzQjIls1DDQjIQRbNQ00IyEFWzUONCMhBls1DzQjVyAgNRA0IyEHWzURNCMhCFs1EjQjIQlbNRMxFiINQAGTJw5kIwg1FDYaATUVNhoCFzUWNhoDFzUXNhoENRgiNRk2GgEqEkABSjYaAScEEkABBCJDNBkiEkAA6jQZIwklCjUmNCYWVwcBNSckNBk0JiULCSMJCzUkMQAiNCdjNSk1KDQpQAC3JSQLrzUlMQA0JzQlIjQkUjQUFjQVUDQWFlA0FxZQNBhQNBkWVwcBUFA0JTQkJAglJAtSUGY0EzQZIwkiVDUaNBo1EzQMFjQNFlA0DhZQNA8WUDQQUDQRFlA0EhZQNBMWUDUqMQAoNCpmJw4nDmQjCGeACG5ld09yZGVysDQUFrAnFGSwNBYWsDQXFrA0FbA0GLA0GRawNA8WsDQOFrA0DRawNAwWsDQgFrA0IRawNCKwNhoFsCNDNCg1JUL/SDQTkzUZNBkiEkH/CicHsCJDNhoEKRJAACw2GgIXNhoDFwshCitklAo1HzQNNB8PRDQNNB8JNQ00DDQfCDUMNA01HkL+yjYaAhc1H0L/3DYaAxc1HzQPNB8PRDQPNB8JNQ80DjQfCDUONA81HkL+oDEWIwk4ECMSMgoxFiMJOAcSEDEWIwk4ECUSMgoxFiMJOBQSEBFB/kUxFiMJOBc1IjEWIwk4ADEAEkQxFiMJOBAjEkAAXjIKMRYjCTgRcAA1HDUbNBxEMRYjCTgRNSAxFiMJOBI1ITYaAScEEkAAGicIZDQgEkQ0DzQhCDUPJxVkNR00DzUeQv3kJwVkNCASRDQNNCEINQ0nFmQ1HTQNNR5C/coiNSAxFiMJOAg1IUL/tTYaAhciDTYaAhcnE2QYIhIQREL9WTYaAhciEjYaAxciDRBENhoDFycRZBgiEjYaAxcnEmQPEERC/TQxAChiNQo0CiJbNQA0CiEEWzUBNAohBVs1AjQKIQZbNQM0ClcgIDUENAohB1s1BTQKIQhbNQY0CiEJWzUHJwVkNjAAEkAAbScIZDYwABJAAFQiQzQIIg1ENjAANAgxAIgEDDQAFjQBFlA0AhZQNAMWUDQEUDQFFlA0BhZQNAcWUDULMQAoNAtmJxewJxRksDYwABawNAMWsDQBFrA0CBawMRewI0MnFWQ1CTQDNQgiNQNC/58nFmQ1CTQBNQgiNQFC/5A2GgEXIhI2GgEXIxIRRDYaARcnCmQSFEQxACcLZBJEJwo2GgEXZyNDMQAnCWQSRDYaA4ABThI2GgMqEhFENhoDKhJAAAo2GgE2GgIXZyNDNhoBNhoCZ0L/9DEAJwlkEkQnCzYcAWcjQzEAJwlkEkSxJbIQNjAAshEishIyCrIUsyNDIkMxACcJZBJDMQAnCWQSQzEAKGI17DTsIls14TTsIQRbNeI07CEFWzXjNOwhBls15DTsVyAgNeU07CEHWzXmNOwhCFs15zTsIQlbNegiNekjNeojNes04jThCDXiNOQ04wg15DTiIg1AALk05CINQACMNOkiDUAAWSI16DThFjTiFlA04xZQNOQWUDTlUDTmFlA05xZQNOgWUDXtMQAoNO1mMQAoaIAIY2xvc2VvdXSwJwVkFrA04hawNOoWsCcIZBawNOQWsDTrFrAxF7AjQyNDJwVkIhJAABI06jTrCDXrIjTpMQCIAkBC/4006jTrCDXqIjTpMQCIAi5C/3snCGQiEkAAFDTqNOsINesnCGQ05DEAiAISQv9YNOk05Ag16UL/TicFZCISQAAUNOo06wg16icFZDTiMQCIAexC/ys06TTiCDXpQv8hIjXYIjXZIjXaIjXbgSCvNdwiNd0iNd6B//////////8PNd802BY02RZQNNoWUDTbFlA03FA03RZQNN4WUDTfFlA14DEAKDTgZicZJxlkIwhnI0MnCTEAZzYaBRc2GgcXCyEKK2SUD0QnFDYaAGcnFTYaAWcnFjYaAmcnCDYwAGcnBTYwAWcrNhoDF2eAFlBSSUNFX0NVUlJFTkNZRGVjaW1hbHM2GgQXZycTNhoFF2cnETYaBhdnJxI2GgcXZycOImeACkxBU1RfUFJJQ0UiZ4AKTEFTVF9UUkFERSJngAhCRVNUX0JJRCJngAhCRVNUX0FTSyJnJxCBFGeAC1RGRUVfVElFUl8yIQVngAtURkVFX1RJRVJfM4EOZ4ALVEZFRV9USUVSXzSBDWeAC1RGRUVfVElFUl81IQ9ngAtURkVFX1RJRVJfNiEKZycPIQ9ngAtNRkVFX1RJRVJfMiEEZ4ALTUZFRV9USUVSXzOBBmeAC01GRUVfVElFUl80JWeAC01GRUVfVElFUl81IQ5ngAtNRkVFX1RJRVJfNiJngA1NTV9GRUVfVElFUl8xImeADU1NX0ZFRV9USUVSXzIiZ4ANTU1fRkVFX1RJRVJfMyJnJwoiZycLNhwBZyNDI0M18DXvNe407iISQAAXsSWyEDTushE077ISNPCyFCKyAbNCABCxI7IQNO+yCDTwsgcisgGziQ==",
+            "clearp": "BoEBQw==",
+            "epp": 2,
+            "gs": {
+              "BASE_CURRENCY": {
+                "tb": "ALGO",
+                "tt": 1
+              },
+              "BASE_CURRENCY_DECIMALS": {
+                "tt": 2,
+                "ui": 6
+              },
+              "BASE_CURRENCY_ID": {
+                "tt": 2
+              },
+              "BEST_ASK": {
+                "tt": 2
+              },
+              "BEST_BID": {
+                "tt": 2
+              },
+              "BKA": {
+                "tb": "\ufffdҾ{Q~\ufffd`\ufffd\ufffdC\ufffd\u000e\ufffd\"\ufffdR\ufffdo\ufffd\ufffd\ufffd`\ufffd\ufffdx\r\u0010\ufffd\ufffd\n\ufffd",
+                "tt": 1
+              },
+              "CRA": {
+                "tb": "\ufffd\ufffd\ufffd\ufffd\u0013\ufffdC\n\ufffdi]W\r\ufffd}\ufffd\ufffd\ufffd\ufffdM\ufffd\ufffd\ufffd\u001f;\"Ǡ\ufffd1\ufffd\ufffd",
+                "tt": 1
+              },
+              "LAST_PRICE": {
+                "tt": 2
+              },
+              "LAST_TRADE": {
+                "tt": 2
+              },
+              "MFEE_TIER_1": {
+                "tt": 2,
+                "ui": 12
+              },
+              "MFEE_TIER_2": {
+                "tt": 2,
+                "ui": 8
+              },
+              "MFEE_TIER_3": {
+                "tt": 2,
+                "ui": 6
+              },
+              "MFEE_TIER_4": {
+                "tt": 2,
+                "ui": 4
+              },
+              "MFEE_TIER_5": {
+                "tt": 2,
+                "ui": 2
+              },
+              "MFEE_TIER_6": {
+                "tt": 2
+              },
+              "MIN_ORDER_SIZE": {
+                "tt": 2,
+                "ui": 1000000
+              },
+              "MIN_PRICE_INC": {
+                "tt": 2,
+                "ui": 5
+              },
+              "MIN_SIZE_INC": {
+                "tt": 2,
+                "ui": 1000000
+              },
+              "MM_FEE_TIER_1": {
+                "tt": 2
+              },
+              "MM_FEE_TIER_2": {
+                "tt": 2
+              },
+              "MM_FEE_TIER_3": {
+                "tt": 2
+              },
+              "MTN": {
+                "tt": 2
+              },
+              "ORDER_COUNTER": {
+                "tt": 2,
+                "ui": 305404
+              },
+              "PAIR": {
+                "tb": "ALGO_USDC",
+                "tt": 1
+              },
+              "PRICE_CURRENCY": {
+                "tb": "USDC",
+                "tt": 1
+              },
+              "PRICE_CURRENCYDecimals": {
+                "tt": 2,
+                "ui": 4
+              },
+              "PRICE_CURRENCY_ID": {
+                "tt": 2,
+                "ui": 81981957
+              },
+              "TFEE_TIER_1": {
+                "tt": 2,
+                "ui": 20
+              },
+              "TFEE_TIER_2": {
+                "tt": 2,
+                "ui": 16
+              },
+              "TFEE_TIER_3": {
+                "tt": 2,
+                "ui": 14
+              },
+              "TFEE_TIER_4": {
+                "tt": 2,
+                "ui": 13
+              },
+              "TFEE_TIER_5": {
+                "tt": 2,
+                "ui": 12
+              },
+              "TFEE_TIER_6": {
+                "tt": 2,
+                "ui": 10
+              },
+              "account_counter": {
+                "tt": 2,
+                "ui": 13917
+              }
+            },
+            "gsch": {
+              "nbs": 32,
+              "nui": 32
+            },
+            "lsch": {
+              "nbs": 16
+            }
+          }
+        },
+        "State": {
+          "Deleted": false,
+          "LocalState": null
+        }
+      }
+    ],
+    "AssetResources": null
+  },
+  "Creatables": null,
+  "Hdr": {
+    "earn": 27521,
+    "fees": "A7NMWS3NT3IUDMLVO26ULGXGIIOUQ3ND2TXSER6EBGRZNOBOUIQXHIBGDE",
+    "frac": 2047917345,
+    "gen": "testnet-v1.0",
+    "gh": "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=",
+    "prev": "blk-EWRYEMIXF5RZGH3FX6WYUSTK7FTCB52BWGJVGWSVWSXO7KLXWIIQ",
+    "proto": "https://github.com/algorandfoundation/specs/tree/44fa607d6051730f5264526bf3c108d51f0eadb6",
+    "rate": 42,
+    "rnd": 26910000,
+    "rwcalr": 27000000,
+    "rwd": "7777777777777777777777777777777777777777777777777774MSJUVU",
+    "seed": "qAGpjhsqGflHDC2QEjwfpRTXEKjVo1DwshaB4XDD9DE=",
+    "spt": {
+      "0": {
+        "n": 26909952
+      }
+    },
+    "tc": 153348349,
+    "ts": 1673397868,
+    "txn": "YlHc2weI18c2RbApZQos0is6PiGEIAOlY4Mj/zx3Va8=",
+    "txn256": "TodzSZUALWBHme8F+J0N2IGI92CPc/ubOu8m3La2FMU="
+  },
+  "KvMods": null,
+  "PrevTimestamp": 1673397864,
+  "StateProofNext": 0,
+  "Totals": {
+    "notpart": {
+      "mon": 347207129836,
+      "rwd": 346468
+    },
+    "offline": {
+      "mon": 2544590110577384,
+      "rwd": 2526267564
+    },
+    "online": {
+      "mon": 7580062682392780,
+      "rwd": 7580062232
+    },
+    "rwdlvl": 27521
+  },
+  "Txids": {
+    "9O78fpLiwXyHZvrviXIXK/bVV3nEZ3AuitOprdgR5X8=": {
+      "Intra": 3,
+      "LastValid": 26910996
+    },
+    "K4pu32z3IylFiPivddikV5oWqNGchhkiv8AZybHKQOQ=": {
+      "Intra": 0,
+      "LastValid": 26910989
+    },
+    "UKkyzCkYQWhJ1HVaEARMqb19eGGdmDgWvUmDXKEFOzs=": {
+      "Intra": 2,
+      "LastValid": 26910998
+    },
+    "oy+SmiO2nLzmj4wtEGjPMNhAClnlmjVkPphGJwHltTA=": {
+      "Intra": 1,
+      "LastValid": 26910989
+    }
+  },
+  "Txleases": null
+}

--- a/features/resources/v2algodclient_responsejsons/statedelta_testnet_26091001.json
+++ b/features/resources/v2algodclient_responsejsons/statedelta_testnet_26091001.json
@@ -1,0 +1,216 @@
+{
+  "Accts": {
+    "Accts": [
+      {
+        "Addr": "7777777777777777777777777777777777777777777777777774MSJUVU",
+        "AuthAddr": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ",
+        "MicroAlgos": 2051818321,
+        "RewardedMicroAlgos": 0,
+        "RewardsBase": 0,
+        "SelectionID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "StateProofID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "Status": 2,
+        "TotalAppLocalStates": 0,
+        "TotalAppParams": 0,
+        "TotalAppSchema": {},
+        "TotalAssetParams": 0,
+        "TotalAssets": 0,
+        "TotalBoxBytes": 0,
+        "TotalBoxes": 0,
+        "TotalExtraAppPages": 0,
+        "VoteFirstValid": 0,
+        "VoteID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "VoteKeyDilution": 0,
+        "VoteLastValid": 0
+      },
+      {
+        "Addr": "DFOE2Y2BBP4RFRGTL7QO3RGXS55GQRBJQNTWLTMCT6GDPCLBIB3VBEU2ZY",
+        "AuthAddr": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ",
+        "MicroAlgos": 973682748277,
+        "RewardedMicroAlgos": 0,
+        "RewardsBase": 27521,
+        "SelectionID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "StateProofID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "Status": 0,
+        "TotalAppLocalStates": 0,
+        "TotalAppParams": 0,
+        "TotalAppSchema": {},
+        "TotalAssetParams": 0,
+        "TotalAssets": 0,
+        "TotalBoxBytes": 0,
+        "TotalBoxes": 0,
+        "TotalExtraAppPages": 0,
+        "VoteFirstValid": 0,
+        "VoteID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "VoteKeyDilution": 0,
+        "VoteLastValid": 0
+      },
+      {
+        "Addr": "A7NMWS3NT3IUDMLVO26ULGXGIIOUQ3ND2TXSER6EBGRZNOBOUIQXHIBGDE",
+        "AuthAddr": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ",
+        "MicroAlgos": 342106534750,
+        "RewardedMicroAlgos": 0,
+        "RewardsBase": 0,
+        "SelectionID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "StateProofID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "Status": 2,
+        "TotalAppLocalStates": 0,
+        "TotalAppParams": 0,
+        "TotalAppSchema": {},
+        "TotalAssetParams": 0,
+        "TotalAssets": 0,
+        "TotalBoxBytes": 0,
+        "TotalBoxes": 0,
+        "TotalExtraAppPages": 0,
+        "VoteFirstValid": 0,
+        "VoteID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "VoteKeyDilution": 0,
+        "VoteLastValid": 0
+      },
+      {
+        "Addr": "UKSBQH6FOHPZMEQ7YPDSD3AV54XSXRFG744W6WF4QUFEF5SLXVIL7SQ4GM",
+        "AuthAddr": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ",
+        "MicroAlgos": 300200,
+        "RewardedMicroAlgos": 0,
+        "RewardsBase": 27521,
+        "SelectionID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "StateProofID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "Status": 0,
+        "TotalAppLocalStates": 0,
+        "TotalAppParams": 0,
+        "TotalAppSchema": {},
+        "TotalAssetParams": 0,
+        "TotalAssets": 0,
+        "TotalBoxBytes": 0,
+        "TotalBoxes": 0,
+        "TotalExtraAppPages": 0,
+        "VoteFirstValid": 0,
+        "VoteID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "VoteKeyDilution": 0,
+        "VoteLastValid": 0
+      },
+      {
+        "Addr": "CIORVXLOUCICNC4Q53SMPGZXDHCGNV55GQKLVVPCMM4KAXJVO4LOUC2OWU",
+        "AuthAddr": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ",
+        "MicroAlgos": 157628000,
+        "RewardedMicroAlgos": 0,
+        "RewardsBase": 27521,
+        "SelectionID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "StateProofID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "Status": 0,
+        "TotalAppLocalStates": 0,
+        "TotalAppParams": 0,
+        "TotalAppSchema": {},
+        "TotalAssetParams": 0,
+        "TotalAssets": 0,
+        "TotalBoxBytes": 0,
+        "TotalBoxes": 0,
+        "TotalExtraAppPages": 0,
+        "VoteFirstValid": 0,
+        "VoteID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "VoteKeyDilution": 0,
+        "VoteLastValid": 0
+      }
+    ],
+    "AppResources": [
+      {
+        "Addr": "ELKQVGOV7YWJOGVQMIIYP3ZLE7SQDO4RGW5VUDVDC35XW7NUHLKK3TLEFY",
+        "Aidx": 67734391,
+        "Params": {
+          "Deleted": false,
+          "Params": {
+            "approv": "BSAEAAEIECYBIH75jkxoZPFJ/OQrTT+QRggg2DjfLsTeDmmfkJ4MepPUMRkiEkAAAQAxGCISQADoNhoAgAF1EkAAdTYaAIABYRJAADc2GgCAAXISQAABADEAKBJEMQkyAxJEMSAyAxJEMRuBAhJEMgg2GgFlNQQ1BTQERDYaAWkjQgCeMQAoEkQxCTIDEkQxIDIDEkQxG4EDEkQyCDYaAWU1AjUDNAIURDYaATYaAjIHFlBnI0IAajEAgCASHRrdbqCQJouQ7uTHmzcZxGbXvTQUutXiYzigXTV3FhJEMQkyAxJEMSAyAxJENhoBFTUBIjUANAA0AQxAAAQjQgAjNhoBNAA0ACQIUjYaATQAJAg0ACUIUogACzQAJQg1AEL/0iNDNQc1BjQGZCJbNQg0Bxc1CTQINAkPQAAINAk0CAlCAAU0CDQJCYHoBws0CAqBZAxENAY0BzIHFlBniQ==",
+            "clearp": "BYEBQw==",
+            "gs": {
+              "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000": {
+                "tb": "\u0000\u0000\u0000\u0000\u00016\ufffd\ufffd\u0000\u0000\u0000\u0000c\ufffd\u0006l",
+                "tt": 1
+              },
+              "\u0000\u0000\u0000\u0000\u0003\ufffdWM": {
+                "tb": "\u0000\u0000\u0000\u0000\u0005\ufffd\ufffd\u0000\u0000\u0000\u0000\u0000c\ufffd\u0006l",
+                "tt": 1
+              },
+              "\u0000\u0000\u0000\u0000\u0004\u0004a\u0016": {
+                "tb": "\u0000\u0000\u0000\u0000\u0005\ufffdg\ufffd\u0000\u0000\u0000\u0000c\ufffd\u0006l",
+                "tt": 1
+              },
+              "\u0000\u0000\u0000\u0000\u0004\u0004cN": {
+                "tb": "\u0000\u0000\u0000\u0000\u0005\ufffdg\ufffd\u0000\u0000\u0000\u0000c\ufffd\u0006l",
+                "tt": 1
+              },
+              "\u0000\u0000\u0000\u0000\u0004\u0004c\ufffd": {
+                "tb": "\u0000\u0000\u0000\u0004\u0010N\ufffd\u0010\u0000\u0000\u0000\u0000c\ufffd\u0006l",
+                "tt": 1
+              },
+              "\u0000\u0000\u0000\u0000\u0004\ufffd\ufffdq": {
+                "tb": "\u0000\u0000\u0000\u0000O\ufffd\ufffd\ufffd\u0000\u0000\u0000\u0000c\ufffd\u0006l",
+                "tt": 1
+              }
+            },
+            "gsch": {
+              "nbs": 64
+            }
+          }
+        },
+        "State": {
+          "Deleted": false,
+          "LocalState": null
+        }
+      }
+    ],
+    "AssetResources": null
+  },
+  "Creatables": null,
+  "Hdr": {
+    "earn": 27521,
+    "fees": "A7NMWS3NT3IUDMLVO26ULGXGIIOUQ3ND2TXSER6EBGRZNOBOUIQXHIBGDE",
+    "frac": 2047917387,
+    "gen": "testnet-v1.0",
+    "gh": "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=",
+    "prev": "blk-GZHAFODTPQOXM3ZJ6N64YEZXIIT74QPAMXJEAFW3B654MFRZNPZA",
+    "proto": "https://github.com/algorandfoundation/specs/tree/44fa607d6051730f5264526bf3c108d51f0eadb6",
+    "rate": 42,
+    "rnd": 26910001,
+    "rwcalr": 27000000,
+    "rwd": "7777777777777777777777777777777777777777777777777774MSJUVU",
+    "seed": "tf1bxuREZbya4dNpQMy6ZcUohZi+ayRyfxN4DEuiuSA=",
+    "spt": {
+      "0": {
+        "n": 26909952
+      }
+    },
+    "tc": 153348351,
+    "ts": 1673397871,
+    "txn": "0dU+1T9t4hwDkLCDUZi5FoE1WmxxskFwKTk8W6TYCp0=",
+    "txn256": "NnC3O9K/PkCkBfyuiba9M6ablZnEPAwMIIH4Cf56+y4="
+  },
+  "KvMods": null,
+  "PrevTimestamp": 1673397868,
+  "StateProofNext": 0,
+  "Totals": {
+    "notpart": {
+      "mon": 347207131836,
+      "rwd": 346468
+    },
+    "offline": {
+      "mon": 2544590110575384,
+      "rwd": 2526267564
+    },
+    "online": {
+      "mon": 7580062682392780,
+      "rwd": 7580062232
+    },
+    "rwdlvl": 27521
+  },
+  "Txids": {
+    "CEf5ZDqRJvndzXVYsA7HpC+W+J07ZINW8o5HlF1DqQk=": {
+      "Intra": 1,
+      "LastValid": 26910999
+    },
+    "yhw/oQ/H89oSf+er3dNjtglFLPBFZpSOL7yaZRB+4fs=": {
+      "Intra": 0,
+      "LastValid": 26911000
+    }
+  },
+  "Txleases": null
+}

--- a/features/resources/v2algodclient_responsejsons/statedelta_testnet_26091002.json
+++ b/features/resources/v2algodclient_responsejsons/statedelta_testnet_26091002.json
@@ -1,0 +1,518 @@
+{
+  "Accts": {
+    "Accts": [
+      {
+        "Addr": "7777777777777777777777777777777777777777777777777774MSJUVU",
+        "AuthAddr": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ",
+        "MicroAlgos": 2051818321,
+        "RewardedMicroAlgos": 0,
+        "RewardsBase": 0,
+        "SelectionID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "StateProofID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "Status": 2,
+        "TotalAppLocalStates": 0,
+        "TotalAppParams": 0,
+        "TotalAppSchema": {},
+        "TotalAssetParams": 0,
+        "TotalAssets": 0,
+        "TotalBoxBytes": 0,
+        "TotalBoxes": 0,
+        "TotalExtraAppPages": 0,
+        "VoteFirstValid": 0,
+        "VoteID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "VoteKeyDilution": 0,
+        "VoteLastValid": 0
+      },
+      {
+        "Addr": "6DJL462RP2DWBGMJIPDQ5PJCXRJKI34Z4GRWB3MEPAGRBAPTBL7U42RDYI",
+        "AuthAddr": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ",
+        "MicroAlgos": 550505000,
+        "RewardedMicroAlgos": 0,
+        "RewardsBase": 27521,
+        "SelectionID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "StateProofID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "Status": 0,
+        "TotalAppLocalStates": 0,
+        "TotalAppParams": 0,
+        "TotalAppSchema": {},
+        "TotalAssetParams": 0,
+        "TotalAssets": 0,
+        "TotalBoxBytes": 0,
+        "TotalBoxes": 0,
+        "TotalExtraAppPages": 0,
+        "VoteFirstValid": 0,
+        "VoteID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "VoteKeyDilution": 0,
+        "VoteLastValid": 0
+      },
+      {
+        "Addr": "A7NMWS3NT3IUDMLVO26ULGXGIIOUQ3ND2TXSER6EBGRZNOBOUIQXHIBGDE",
+        "AuthAddr": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ",
+        "MicroAlgos": 342106544750,
+        "RewardedMicroAlgos": 0,
+        "RewardsBase": 0,
+        "SelectionID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "StateProofID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "Status": 2,
+        "TotalAppLocalStates": 0,
+        "TotalAppParams": 0,
+        "TotalAppSchema": {},
+        "TotalAssetParams": 0,
+        "TotalAssets": 0,
+        "TotalBoxBytes": 0,
+        "TotalBoxes": 0,
+        "TotalExtraAppPages": 0,
+        "VoteFirstValid": 0,
+        "VoteID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "VoteKeyDilution": 0,
+        "VoteLastValid": 0
+      },
+      {
+        "Addr": "ZLCQBSXNXR6R36N2DWPTO64NNGR2GVZFKRFRHO6YPVP2JHNQYKEX66FJRE",
+        "AuthAddr": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ",
+        "MicroAlgos": 48192186764,
+        "RewardedMicroAlgos": 0,
+        "RewardsBase": 27521,
+        "SelectionID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "StateProofID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "Status": 0,
+        "TotalAppLocalStates": 0,
+        "TotalAppParams": 0,
+        "TotalAppSchema": {},
+        "TotalAssetParams": 0,
+        "TotalAssets": 1,
+        "TotalBoxBytes": 0,
+        "TotalBoxes": 0,
+        "TotalExtraAppPages": 0,
+        "VoteFirstValid": 0,
+        "VoteID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "VoteKeyDilution": 0,
+        "VoteLastValid": 0
+      }
+    ],
+    "AppResources": [
+      {
+        "Addr": "LWOXAHEF32ISGGQSQTOFFTVSVUGJIRRFSIJYRFVL4PK4KS7MNG4SBWKYK4",
+        "Aidx": 110096026,
+        "Params": {
+          "Deleted": false,
+          "Params": {
+            "approv": "ByAGAAgBIL0BAyYCAAQVH3x1NhoAgAQD3VB4EkAAkDYaAIAEpJ1KeBJAAGU2GgCABBiTksUSQAAzNhoAgARHwgwjEkAAAQAxGSISMRgiExBENhoBFzULNhoCNQw0CzQMiALyNQ0pNA1QsCRDMRkiEjEYIhMQRDYaARc1BTYaAjUGNAU0BogCkzUHKTQHULAkQzEZIhIxGCITEEQ2GgEXNQM2GgI1BDQDNASIAfUkQzEZIhIxGCISEEQ2GgEXNQA2GgI1ATYaAzUCNAA0ATQCiAGsJEM1GzQbgQcIIwojC4k1GjQaiP/tIwohBBghBQqJNRw0HIj/3SMKIQQYIQUYiTUYNRc0GBUlEkQ0F4j/0RY1GTQZNBlkNBg0F4j/0ogAAmeJNR81HjUdNB8iEkAALDQfJBJAABQ0H4ECEkAAAQA0HVcAQDQeUEIAGTQdVwAgNB5QNB1XQCBQQgAINB40HVcgQFCJNSI1ITUgNCAWNCDRAFADNCE0ItAANSQ1IzQkJBJENCNXACCJNRY1FTUUNBQ0FDQVNBaI/8uI/2OJNS01LDQsiP85FmQlNCyI/0ELJVg0LBZQNC1QmIk1JjUlIjUnNCeBPwxBAG80JxaAYGFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWc0JyQINSdC/4koNCUWNCUWUDQmUGeJNS40Loj+hyhkIlsONC6I/n0oZCNbDxCJNSs0KyMYIhI0KyhkIlsjCA0QNCuB6AcIMgaBEAgOEIk1EzUSNRE0ESMYIhJENBMVJRJENBE0E4j/IzQRNBI0E4j+6Ik1KTUoKGQiWyMINCgSNCiI/6oRRDQoiP+jNSo0KDQpKGRXECCI/sAoNCgWKGQjWxZQKGRXECBQZzQqQAAqKGQiWyhkI1sJgegLD0EAKygoZCJbFihkIluB4AsJFlAoZFcQIFBnQgARKChkIlsWNCgWUChkVxAgUGeJNQk1CDQIiP8iFEAAGzQINAlXAgCI/mw1CjQKFRZXBgA0ClA1CkIADyg1CjQKFRZXBgA0ClA1CjQKiTUPNQ40Doj+6EQ0DjQPVwIAiP41NRA0EBUWVwYANBBQNRA0EIk=",
+            "clearp": "BzEbgQASQAABAIEBQw==",
+            "gs": {
+              "": {
+                "tb": "\u0000\u0000\u0000\u0000\u0001\ufffd\ufffd0\u0000\u0000\u0000\u0000\u0001\ufffd\ufffdP\ufffd\u001d\ufffd\u000erUQڀf\u001bL1\u0014sxݩ\ufffd\ufffdӲl\ufffd\ufffd\u001d\ufffd\ufffdk4\ufffd\ufffd",
+                "tt": 1
+              },
+              "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000": {
+                "tb": "/\b\u001b\ufffd\ufffd\ufffd\ufffdD}\ufffd\ufffdu(F\ufffd\ufffd?u\r\ufffdXP\ufffdA \ufffdClN\ufffd\ufffd\ufffdΨ\ufffd\ufffd`\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd8\ufffd\ufffdZ\u0001\ufffdp\ufffd\ufffd\ufffd\ufffdȌy۴\ufffd\ufffd^\u001eD\r\u0014x\ufffd8^X\ufffd\u0006*.\ufffd\ufffd\u0007_${\u0014~LI5\ufffd\ufffdg\u0016\ufffd\ufffdj\ufffd",
+                "tt": 1
+              },
+              "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001": {
+                "tb": "|\ufffd\ufffd2I\ufffd?\ufffd19'\u0014l\ufffd`\ufffd,\ufffd\ufffd\ufffd\ufffdU̯\ufffd\u000e\u0011\ufffd\ufffd5n\ufffd\ufffdg\ufffd0\ufffdl͚L\ufffd\\\ufffd1I\ufffd\ufffd\ufffd\r8\ufffd\u001c>G\u001e&\ufffd\ufffdi\ufffdG\u0006\ufffd\ufffd\u00030\u0011\ufffd2\ufffd\ufffda誚\u0015\u0017TMs\ufffdBsn\u0014\ufffd\ufffdXd\ufffd\u001a\ufffdd\ufffd)",
+                "tt": 1
+              },
+              "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0002": {
+                "tb": "\"F0\u0011׿D\ufffd\ufffdȨ\ufffd/\u0017\u000b\u001cO\ufffd\ufffd\ufffdC\ufffdA\ufffd\u000b\ufffd\ufffdj\ufffd\ufffd:\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\"\ufffd\u0016\ufffd\ufffdDS\ufffd\ufffd\ufffdk\ufffdhyЎ\u001c\ufffd\ufffd㬚9\ufffdR\ufffd\ufffdZ\ufffd\ufffdw\ufffd0\ufffd\ufffd\ufffdSOˀ\ufffdZ\ufffd\ufffd.\ufffd\u0006\ufffd\ufffdo@Z\u000e#?\ufffd",
+                "tt": 1
+              },
+              "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0003": {
+                "tb": "\u0019\ufffd\ufffdǸr\ufffdٺa\ufffd!u\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd(\ufffdL\ufffd\ufffdK\ufffd\ufffd\ufffdI\u001d\u001a멊\f\ufffd?\ufffd\ufffd\ufffd^~\ufffdg\ufffdc{\ufffdIp\u0010\ufffd\u00057\u0011\ufffdϧ\ufffdʱ\ufffd\u0018QCDp\ufffd9*\ufffdFv\ufffd\ufffd\ufffdrB:5\ufffd\u000eBNy\ufffd\ufffd\ufffd3\ufffdm\ufffd\u0015\ufffds",
+                "tt": 1
+              },
+              "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0004": {
+                "tb": "\ufffd\ufffd$/@\u0003<\u0016\u0010\u0017\ufffdP\ufffd}\u0012hIs\ufffd\u001a\ufffd\ufffd\ufffd\ufffdi\u0017&\ufffdo\ufffdm~\ufffd,\u0001\ufffd4\ufffd\ufffd\u0015\ufffd%v\ufffd\ufffd\ufffd\ufffd\ufffd\"\ufffdzl\u001d?\ufffd\ufffd\ufffdc\ufffdV\ufffd\ufffdH\ufffdo\ufffd\ufffd\u001c\ufffd3n\ufffd\ufffd\u0014\u0019\ufffd\ufffd.\ufffd\ufffd&\ufffd$\u0006\ufffd\ufffd\ufffdq\u000f\ufffd\u000f\ufffd\ufffd+\ufffd)",
+                "tt": 1
+              },
+              "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0005": {
+                "tb": "\ufffd\ufffd9\ufffd.\\ӌ\ufffdT\u001aǮ\ufffd\ufffd.|P\ufffdʐQ\u000b\ufffd\u0004#\ufffd\u0004\u0014\u0011\u000b\ufffd\ufffd\ufffdM\ufffdR5<\ufffd\u0002\ufffd\ufffd7\u0010\u0015\ufffd\ufffd\ufffd\u0017h\ufffd\ufffd\ufffd\ufffd>\ufffdJ\ufffd#\u0004\ufffd\ufffd$ٿ\ufffd\ufffd\ufffd\u0013\ufffd\u0006p\ufffd\ufffd\ufffd]4\ufffd\ufffde\ufffd\f\ufffdn\ufffd\ufffd\ufffdTE\ufffd\ufffd\u000f\t\ufffd}",
+                "tt": 1
+              },
+              "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0006": {
+                "tb": "\ufffd\ufffd{\ufffd.]l\u001e\ufffdS\ufffd\ufffd\ufffd\u0018\ufffd\ufffd\u000b\ufffdb\ufffd\u0014\ufffd\ufffd\ufffd1\ufffdE\ufffd\ufffd\ufffdz\ufffd\r\u0013\n\u001bb\u0015\ufffd\ufffd\u000f\ufffd\u0010\ufffd\u0002=uY\ufffd\u001faM\ufffdHv8\ufffd\ufffd\u0000\ufffd>\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffdF\ufffdaϯw\ufffd \ufffd\u000e\ufffdl\ufffd`H\ufffd\u001b\u0001\ufffd\ufffd\ufffd\u0012\ufffd\ufffd(\ufffd\u0014",
+                "tt": 1
+              },
+              "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0007": {
+                "tb": "\ufffd\ufffd\ufffd>:\ufffd\ufffd\u0019\ufffd\ufffd\ufffd\ufffd\ufffd\u0014\ufffd\u0010M\ufffd\ufffd\u0013#!a\ufffdb\ufffd</\nٮD\u0002\ufffd\u001b\n\ufffd\ufffd\ufffd\ufffdg\ufffd\ufffd\ufffd\u0000\ufffd/Nu\ufffd\u0011\u0001\ufffd}\ufffd\u0006i\ufffd\u0017\ufffdQ\ufffd\ufffdd\t\ufffdC\ufffdy\u0017\ufffd\ufffdp\u000f\ufffd\ufffd\ufffd\ufffd=n\ufffd\ufffd\ufffd\u0002\ufffd&*\t\ufffdhfU\ufffd\ufffd\ufffd",
+                "tt": 1
+              },
+              "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\b": {
+                "tb": "\ufffd\u0004\u0011\ufffd\u0007@\u001d\ufffd\ufffdI\u0004#(jy\ufffd\ufffdp8\ufffdÎ\ufffd˰\ufffd*\u001e|\ufffd3?\ufffd\rw\ufffdWw\u0003ص$\ufffdX\u0001\ufffd>\ufffd\ufffdM|8\ufffdvo\ufffd\ufffdDS\ufffdN\u001crAde\ufffd\u0013\fRu.\ufffd\ufffd\ufffd;\r\u000e{~&\ufffd.)N\ufffdy2\u0006\u0000\ufffdXQ\ufffd\ufffdF",
+                "tt": 1
+              },
+              "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\t": {
+                "tb": "\ufffd\u0019/\ufffdW\ufffdxO\ufffd\ufffd\u0003\ufffd\ufffd\u0007\ufffd'\ufffdňv\ufffd\ufffdw\ufffd|-\ufffdl\"q\ufffd-EL\ufffd\ufffdrK\ufffd\ufffdU\ufffd\u000e~\u000bڱ0л\ufffd\ufffd\ufffd\u000b\ufffdT\ufffdV\ufffd:\u000bx\ufffd\u001e\u001bk\ufffd\ufffdՏůamoh`C\u00165\ufffd\u0004\ufffd!\ufffd\ufffd0Ӵ\ufffd\u0007x\ufffdH\ufffd",
+                "tt": 1
+              },
+              "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\n": {
+                "tb": "]|S#\u0016\ufffdܙ6\ufffd\ufffd\ufffd\b\ufffd\u000f\ufffd\u0007\ufffd\ufffdWH\ufffdJ\ufffd\ufffd\ufffd\ufffd<\ufffd\u0011K\ufffdr\u0000\ufffd\ufffd7#\ufffd\ufffd\ufffdOB\ufffd\ufffd\ufffd\u0002\u0011\ufffd}\ufffd\ufffd3\ufffd+\ufffd[P#C\ufffd:\u001dc>\ufffdzP\ufffd\ufffd\u000e')T\ufffdQ\ufffd&n(\ufffd\ufffd\u0014\ufffd\ufffdx\ufffd\ufffd\ufffd\t\ufffd0'\ufffd\ufffd]",
+                "tt": 1
+              },
+              "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u000b": {
+                "tb": "\ufffd\ufffd\ufffd#TPFo^\ufffdc\u0019\ufffd\ufffd\u001a'\ufffd\u0007QT\ufffd\ufffd\ufffd\u0017\ufffd\ufffd\ufffdJF\ufffd\ufffd\ufffd\u0000\\\ufffd\ufffd\ufffd1\ufffd\ufffd\ufffd\u001d#6\r\ufffd\ufffd9Ԙ\ufffd\u0012\ufffd\ufffd[+M\nH\u0016\ufffdƠ\ufffdQ\ufffd\ufffd\ufffd\ufffd\ufffdv\ufffd\ufffd{$.F\u0003\ufffdݥ^\ufffd\ufffd\ufffd\ufffd\f\ufffd\ufffdO>fN\u0001?\ufffd",
+                "tt": 1
+              },
+              "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\f": {
+                "tb": ".\ufffd$\ufffd?z\ufffdc\u0016\ufffd\ufffdQ,\ufffd\ufffdM\u001d.LK\ufffd\ufffdh\u0006O\ufffd\ufffd\ufffd\ufffd߀[\ufffd\u001c\ufffd\u0012\ufffd\"\ufffd\ufffdg\u0012\ufffd\ufffd\ufffd\ufffd՚\u0001\ufffd\ufffd\ufffd\ufffdK\ufffd3\ufffd\\8L\u0007\ufffd_ݪ\u0007A\ufffdy\ufffd\ufffd\u0003F3ka\u000e\ufffd\u0001;.\ufffd  \ufffd\ufffd=\u001aY\ufffd\u000787",
+                "tt": 1
+              },
+              "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\r": {
+                "tb": "~\u0003|\ufffd{a\ufffd\ufffd{}\ufffd\ufffd\ufffd\u0018\ufffdi\u0001\ufffd>\ufffd~\ufffd]wXvwz\t\ufffd\ufffd!\ufffdG\r\ufffd:\\\ufffd#\u0014y\ufffd)Z\ufffd)@m\ufffd\ufffdM\u0012\ufffd\ufffdr=\ufffd'\ufffd\ufffdTF̮\ufffd\u001fV\ufffdl\ufffd\ufffd#\ufffd\ufffd\ufffd\u001df\ufffd\ufffd\ufffd<p\ufffdE\ufffd\u0015\u0001\ufffd\ufffdbrL\ufffd",
+                "tt": 1
+              },
+              "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u000e": {
+                "tb": "\\\ufffdW\ufffdb\ufffdsH\u0006ڢ\ufffdw\ufffd\u0003\u0013\u001d\ufffd\ufffd3\ufffd\ufffd\ufffd\u001c\ufffd\u0019\u001a \u0017\ufffd\ufffdl\ufffd{\ufffd\ufffd\ufffd\ufffd\ufffdG\ufffdR\ufffd\ufffd\ufffd\\\ufffdw\ufffd\ufffd\ufffd#C\f\ufffd\ufffd\ufffd\u0001t\ufffdx\ufffdN/\ufffd'P\t\ufffd\ufffd\f\ufffd\ufffd\ufffd\ufffd&\u0018p\ufffd\u001cyR\u0015\u0014\ufffdD\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd>,\ufffd\ufffd",
+                "tt": 1
+              },
+              "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u000f": {
+                "tb": "}\ufffd\ufffdT3\ufffd\ufffd\"|\ufffd\ufffdcF\ufffd\u001d8\ufffd\u0018Ҵ\ufffd\u001cՉX\ufffd\ufffd\u001f5\ufffdҸ\u000b\ufffd\ufffd\ufffd\u0012\ufffd\ufffd\u0003\ufffd\u000f\ufffdb[ hy\ufffd\u001f\ufffdD{\u0000M\ufffdv=cUI7\ufffdI\ufffd\ufffd\ufffdQ\ufffdˊ+\ufffd\ufffd\ufffd\ufffd~!\ufffdZ\ufffd$\ufffd\u000e\ufffd(\ufffd(n\ufffd\ufffdTbh\ufffd\ufffd",
+                "tt": 1
+              },
+              "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0010": {
+                "tb": "\ufffd\ufffd\ufffd'\ufffd\ufffd\ufffd\ufffdXL\ufffd\ufffds\ufffd+\ufffd\ufffd3cYHӽ\u0002hv\ufffd\ufffd)\ufffd\ufffdWM\ufffd\ufffdܬ\ufffd&kv\ufffd׃\ufffd\ufffd\ufffd7\ufffd\ufffdx\ufffd\ufffd\ufffd\u0002\ufffd5R\ufffd\ufffdY\ufffd=\"\ufffd\u0001\ufffdy\ufffd\tY\ufffd&\ufffds\ufffdO\u001f\u0019\u0018''\u001f\ufffdl\ufffd\ufffd\ufffdy+ZGI\ufffdK\ufffd",
+                "tt": 1
+              },
+              "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0011": {
+                "tb": "\u0010_@\b_R\ufffd\ufffdpr\ufffd\ufffd\u0018+\ufffdA#\u0007\u0001\f\ufffd\ufffd\ufffd\u0004\ufffd\ufffdP\ufffdlW\ufffd\ufffdm\ufffd\ufffd\ufffd9\ufffd\ufffd\ufffdk\ufffdLo\ufffd\ufffd\ufffdР\ufffd\u0019\ufffdrF\ufffd\ufffd\ufffd\ufffd8\ufffd\u0014\ufffd͹A\\\r\ufffdNUݞ⍒\u0002^<\ufffdV\ufffde-\ufffdH\u0016q\ufffdnך\u00178\ufffd\u001b\ufffd",
+                "tt": 1
+              },
+              "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0012": {
+                "tb": "1h\ufffd˶\u0005\ufffdW\ufffd\ufffd/\ufffd\ufffd\ufffd:\ufffd\u0015\ufffdj|5\ufffd\ufffd\ufffd\t\ufffdD\u0013\ufffd\" ΐ\ufffd\ufffdX!\ufffdp\ufffd\u0016\u001b\ufffd6\ufffd\b\ufffd\ufffd\u0013\ufffd\u001c\ufffd\u0019\ufffd\ufffdF\ufffd?\ufffdr\ufffd\ufffd\ufffd鷖\ufffd\u000f\u000f\ufffd\ufffdDJ\ufffd\ufffd\u0004\ufffdr\ufffd\ufffdR^f\ufffd\ufffd*\u001e\ufffd\ufffd\f\ufffd\ufffd\fBL",
+                "tt": 1
+              },
+              "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0013": {
+                "tb": "j\u0004\ufffd\ufffd\ufffd\ufffd\ufffd\b\ufffd\rMn=\ufffd\ufffd\ufffdi\ufffd\ufffdzd\ufffd&\u001d'm\ufffdsU\ufffdE\ufffd\ufffdP\ufffd~\ufffd\ufffd3\ufffdN\u0016Y=+\ufffd\u0006d\ufffdHp!\ufffd\ufffd7\ufffda\ufffd\ufffdkg\ufffdU;C<\u000b\ufffd\u000f5O81\ufffdp\u0000\n\u0012G\ufffd\ufffdm-7\ufffd\ufffd4\rʹ\ufffd\ufffdL\ufffd\ufffd",
+                "tt": 1
+              },
+              "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0014": {
+                "tb": "/F\ufffd\u0007Y\ufffdѲ\ufffd\ufffd\ufffd)ϟ\ufffdb\ufffds\ufffd\u0014\ufffd\u0018\u0012\ufffdz\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffdO\u001a0\ufffd\ufffdD\ufffdOg]\ufffd\ufffdk\ufffd\ufffdn\ufffd\ufffd*m7ߘ\ufffd\ufffd(49YD#o\u000f\ufffd\ufffd\ufffd\ufffd)\ufffd\ufffdK\u000e\ufffd\ufffd\ufffd#\ufffd\ufffd\\}\u0014Y\ufffd\u0016\ufffd\ufffdm!XD\ufffd\ufffd\u0005\ufffd",
+                "tt": 1
+              },
+              "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0015": {
+                "tb": "\ufffd\u001d>=5\ufffdf\ufffd\ufffd\ufffd\ufffd'\ufffd>\u0017Y0\ufffd\u001b/ȣ\ufffd\ufffd!\u00030\ufffd\ufffd\ufffd7\ufffd\ufffd\u00048\ufffdJ\tvq\ufffdl\u00141&Ă\ufffd\ufffd\ufffd\ufffd0\u00111\ufffd\ufffd\ufffd \ufffd\fޅ\ufffd-vY7Qk\ufffd\u0002\ufffdx\ufffd¡\ufffd\u0005\ufffd\ufffdJ\ufffd\ufffd\ufffd]/\u0016`\u001c\ufffd7Y4\u0007|\ufffd",
+                "tt": 1
+              },
+              "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0016": {
+                "tb": "\f}\ufffda\ufffd\ufffdC\u001e\ufffd\u0014\ufffd\"\u0000\u0002\ufffdV$\u001e\u0015ϪT\u0006\ufffd\ufffd\ufffd1@\u001b%\u0006\ufffd1\ufffd\ufffd\ufffd!\ufffd[\ufffd\ufffd\u0010\ufffd\ufffdPg ]\ufffd\u00107\fX\ufffd8\ufffd\ufffd\u001adV\ufffd\ufffda\u0002\ufffdt\u0007\ufffdT\ufffd\ufffd\u000e7\ufffd\ufffd\ufffdYu\ufffd\ufffdX\ufffd\ufffdZ\ufffd\ufffdL\ufffdլ\u0017\u0013׍2",
+                "tt": 1
+              },
+              "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0017": {
+                "tb": ")\u000fER+\u0016{^\u0002\ufffd\ufffd\u00145\ufffd\ufffd\u000e\ufffd\ufffd\ufffd\u0011\ufffd\ufffd\ufffdO\ufffd\ufffd\u0005\u0012\u001b\ufffdw\ufffdR\ufffd\r\ufffd\ufffd\ufffd/\ufffd—)v\ufffd\ufffd\ufffd\u0003\u0001h\ufffd\ufffdd\u001d\ufffdw\ufffd'\ufffd\ufffd9\u0004\ufffdZʉZl\ufffd\u000f\u0013n\ufffd\u0004ʽ\ufffd\ufffd~м}W\ufffd\ufffd\ufffd_\ufffdA\ufffd\r\ufffd$\ufffd\\",
+                "tt": 1
+              },
+              "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0018": {
+                "tb": "!\ufffd\f\ufffdS\u0010s1gR\ufffdJ%\ufffd͐\ufffd\ufffd\ufffd\ufffd\ufffdʹ\"'\u001di\ufffd\u0017F$\ufffd\u0006;\ufffd\ufffdݳ\u0015\ufffd\ufffdT'\ufffd\ufffd3#P\u0004Hy\ufffd\ufffd\ufffd\ufffd7Ȏr\ufffd\u0003V\ufffd\ufffd\ufffd\"\ufffd\ufffd Q\ufffd\ufffdG\ufffd\u0017\ufffd\ufffd\ufffd\u001b\u001c\ufffd\ufffd\ufffd\ufffd;44\ufffd\ufffd\"g\ufffd\u001f\ufffdct",
+                "tt": 1
+              },
+              "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0019": {
+                "tb": "\u0014\ufffdm4\ufffd\ufffd_\u0005:UAR\ufffd\ufffd\u001fI0\ufffdE\ufffd\ufffd\u0015_\ufffd\ufffd'!\ufffd[A\ufffd\ufffd\u0016\ufffd\ufffd\u001b\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffdJ\ufffd\ufffd\ufffd\ufffdd\ufffd\ufffd{\ufffdPK\u000f`ZW\u0016\ufffd\ufffd\u0000\ufffd\ufffd\ufffd\ufffd\ufffd\ufffdE\ufffdR@\ufffd\ufffd\ufffdv&J\u0018\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd]\u0000\ufffd\ufffdå\\\ufffdt",
+                "tt": 1
+              },
+              "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u001a": {
+                "tb": "\ufffdr\\\ufffd\ufffd-\\\ufffd/Y\ufffd\ufffd(\ufffd\ufffdK\ufffd\ufffd\ufffḓͱ~\ufffd\ufffdT\ufffd\ufffdp\ufffdqba@\ufffd\\\ufffdc\n\ufffd\ufffd\u0016St\ufffd\ufffdT\ufffd.A\u0015t\u001f\ufffdAy\ufffdCE \ufffd\ufffd\u0018;\ufffd\u00167\ufffd\ufffd((\ufffd\ufffd\ufffd\ufffd\u0011[\ufffd\ufffd7\ufffd=\ufffd\ufffd\u001d\ufffd\ufffd\u0001\ufffd\ufffd\ufffdUe\ufffd\"",
+                "tt": 1
+              },
+              "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u001b": {
+                "tb": "\u001d\ufffd\u001bZ\u001c\ufffd\ufffd=\ufffd\ufffd\ufffdR\u001d\u0010\ufffd|\ufffd6^\ufffd\u001f?\ufffd\u000e+<z\ufffd\ufffd<y\ufffd\u0011D\ufffd\ufffd\ufffd\ufffd\u000b\ufffd\ufffd\ufffd\ufffd򄨅&w۸\ufffd\ufffd\u0005#\ufffd\ufffdt\ufffd\ufffd?\ufffd\ufffd\ufffd8=\ufffd:%\ufffd\ufffdA$0\ufffdP\ufffd\ufffd]-\u0007;\ufffd0\ufffdl\ufffd!\ufffd3\ufffd\u0017\u0017F",
+                "tt": 1
+              },
+              "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u001c": {
+                "tb": "\ufffd\ufffd\ufffd\ufffd=\ufffdp\ufffd\ufffd3\u0011\ufffd\u0004l\ufffd\ufffd)\ufffd\ufffd\ufffdi˖\ufffd\u0010Զ(\ufffd\u00038g\ufffdMT\ufffd)\u000b\ufffd\u000f\ufffd\ufffdE\ufffd\ufffd\ufffdA\ufffd\ufffdC\ufffd\ufffd\u001bv,b\ufffd\ufffd\ufffdOv\ufffd\ufffd\u0006\ufffdy\u000f\ufffd7\ufffd?\u0005\ufffd6\ufffd\ufffdAT\ufffdy\ufffdTJF\ufffd5\ufffd\ufffdg\u001c/*\ufffdS\ufffd",
+                "tt": 1
+              },
+              "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u001d": {
+                "tb": "\ufffdZ\ufffd\ufffdvj9]8-\ufffdG\ufffdT\ufffd\ufffd\"\ufffd\ufffd\ufffd}\ufffdj\ufffdrPgCl\u0017W\ufffd0ߐPNZ\ufffd&\ufffd\ufffd\ufffdo\ufffd\ufffd[\ufffdSX\ufffd/#oӴ\ufffd\ufffdܘ5$\ufffd\ufffdY&\ufffd\ufffd\ufffd\ufffd\u0004\ufffdX\ufffd>\ufffdE\u0011\ufffd\ufffd\ufffdmyu]V\u0013\ufffdת\ufffdS\u001e\ufffd",
+                "tt": 1
+              },
+              "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u001e": {
+                "tb": ";\u0013\ufffd\ufffd\ufffd]\ufffd\ufffd\u0017\ufffd\ufffd\ufffdg\ufffdL\ufffd\f\ufffd\ufffd2\ufffd*\ufffd/]eF\ufffd+\ufffd?\ufffd\ufffdHً\u0018#\ufffd\u0012B>\ufffd_L\ufffd\ufffd\ufffdU\ufffd\ufffd>\ufffd\ufffd\u001f4\ufffdr\ufffd\\\u0018\ufffd\ufffd~gr\ufffds\ufffd\u001e⽽x\u0003\ufffd\ufffd\ufffd˙\ufffd\u0016\ufffd\ufffdÊ\ufffdbʹ\ufffd\ufffd\u0011\ufffd\ufffd",
+                "tt": 1
+              },
+              "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u001f": {
+                "tb": "\ufffd\ufffd1LlD\u0017~@aִ`\ufffd\\\u000f\u0007\ufffd\ufffd:\ufffd\ufffd*\u0010\ufffdUwlM\ufffdG\ufffdp\u0010\ufffd\ufffd\ufffd}\ufffd\ufffdf\ufffd\ufffd\n\u000b\ufffd\ufffd.\ufffd\\h\ufffd\ufffd\ufffd\u000bJ\ufffd20\ufffd\u0004\ufffd(\u0018\ufffd6\ufffd\ufffdL\u000e\u00168\ufffdm\ufffdb\ufffd\u0019\u0002\ufffd\ufffdiD\ufffd_.\ufffd\ufffd&q\ufffd\ufffd+\ufffd\ufffd\ufffd",
+                "tt": 1
+              },
+              "\u0000\u0000\u0000\u0000\u0000\u0000\u0000 ": {
+                "tb": "H\ufffd\ufffd_`\ufffdO6\ufffd\u0017\ufffd\ufffd\u001e\f̰%\ufffd\ufffddid\ufffd\ufffd\ufffd\ufffdz6\ufffd\ufffd\ufffd\ufffd\u0004g\ufffdE5\ufffd);\ufffd\u0007\ufffd \ufffd\u0004\ufffd\u0010\ufffd\ufffd\ufffd\ufffd\ufffda\ufffdQ^\u001c\ufffd\ufffd\ufffd\ufffd4YVܿE9\ufffd\u0019\ufffd3\ufffdh;\ufffdp٤\ufffd}n\ufffd\ufffdߓ\u0003k\ufffd\ufffd\ufffd'J\ufffd",
+                "tt": 1
+              },
+              "\u0000\u0000\u0000\u0000\u0000\u0000\u0000!": {
+                "tb": "\n\ufffd\u000f\u001bT&\ufffd\ufffd\ufffd\u0002\ufffd\ufffd\u001e8\ufffdf:D\ufffd\ufffd|\ufffd)X\ufffdj\ufffd\ufffdd6*\ufffd\u0012\ufffdP\ufffd\ufffdwŎ\u000f\ufffd\ufffd!ϰ\ufffd\u0015w\ufffd\ufffd\ufffdߡ\\g|\ufffd!\ufffd\ufffd1\u0019\u0015\ufffd\ufffd}\ufffd]\u0018\ufffd\ufffd\ufffd\ufffdɢ\ufffd,\ufffdw-4ݒ3=4X<!*\ufffd_R\u0014",
+                "tt": 1
+              },
+              "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\"": {
+                "tb": "\ufffd\ufffd\u000b\ufffd\ufffd\u0011D\t\ufffd2\ufffd\ufffd\u000e\ufffd\ufffd\u0007D\ufffd\ufffd߽\u0012L=.\ufffdʫw\ufffd|\u0005\ufffd\ufffd\u0010|\ufffd&\ufffdC\u000b\ufffd\ufffdL\u0000\ufffd\u0010\ufffd؆\u0006\ufffdS\ufffd}\ufffdE\ufffdpE\ufffd\ufffdjnM\u0005\ufffd\ufffd\ufffdՒF\ufffd\ufffd\ufffdM\tL8C\ufffd|peD\ufffd̻W\ufffd\ufffd\ufffdȖ\u0018\u0013",
+                "tt": 1
+              },
+              "\u0000\u0000\u0000\u0000\u0000\u0000\u0000#": {
+                "tb": "^\ufffdս\ufffd\t\ufffd\ufffd\ufffd\u0019\ufffdjM\ufffdm\u0014+S\u0002m\ufffd\ufffd-\ufffd\ufffdQ\ufffd\ufffd,B\ufffdv\u0010\u000f\ufffdo\u0006JWc\u0017\u0002531\ufffd\ufffd\ufffd\ufffd\tԑ\u001f*\ufffdH\ufffd\ufffdQ\b\ufffd\u0014\nI\ufffd5\u001d\ufffd\ufffd3\ufffd\ufffdX\ufffd\u001dl\ufffd\ufffd?\ufffd@\ufffd\tw\ufffd\u001e\u0004P\ufffd\ufffdx\ufffdIK:*",
+                "tt": 1
+              },
+              "\u0000\u0000\u0000\u0000\u0000\u0000\u0000$": {
+                "tb": "g\ufffd5\ufffd8\ufffd\u001b\ufffd\f\ufffd\ufffd\n\ufffd\u0001\u000f\ufffdk\u0001V\ufffd`\u001cֻj\ufffd4\u000b8\ufffd\ufffd\u0019\ufffd\ufffd\u0011s\u0006\u0006\ufffdPx\ufffd\u0005\ufffd\ufffd\ufffd\ufffd>\ufffdm\ufffd\ufffd\ufffd?W\ufffd\u000e\ufffd\ufffd\ufffd\ufffd*\u001b\ufffd\ufffd\ufffd0:\ufffdғ\ufffd,\ufffd\ufffd\ufffd\ufffd\u001f\ufffd\ufffd\u000e\ufffdo\ufffd\ufffd\ufffd\ufffdA\ufffdu\fS\u0015}\ufffdM",
+                "tt": 1
+              },
+              "\u0000\u0000\u0000\u0000\u0000\u0000\u0000%": {
+                "tb": "U\ufffd\ufffd_\ufffd\ufffd,\ufffd\ufffd\ufffd\ufffd\ufffdLR\ufffdP0\ufffdy\ufffd\ufffd\ufffd\ufffd\"\ufffd\f-\ufffd\ufffd\ufffdxG\ufffd\u0019Y\ufffdD\ufffd\ufffd\u0006b_\ufffd'2\ufffdk\ufffd~\ufffd,\u0006T_\ufffd\ufffd\u001c\u0004\ufffd\ufffdQ\ufffd\ufffdC\ufffdt\ufffd0\ufffd\ufffd}\ufffdm\u0019\ufffd\ufffd\ufffdٟ\ufffd\u0001\ufffd\u001fA\ufffd\ufffd[V\ufffdT\ufffd\ufffdN2\ufffd\u0019",
+                "tt": 1
+              },
+              "\u0000\u0000\u0000\u0000\u0000\u0000\u0000&": {
+                "tb": "\u0016\u0006&\ufffd\ufffd\ufffd\ufffd\u0018\ufffd\ufffdڴ\ufffd\ufffd\ufffd\ufffd|6jt\ufffdu\ufffd\u0003\ufffd\ufffd\ufffdŔ\ufffd\u001b\ufffd\ufffd\tޮb[\ufffdܷG\u001d\ufffd\ufffd>\u0018\ufffd\ufffd\u0019\u0010i5W\ufffd\u00030\u0010\ufffdMr\u0001\ufffd\u0003(\ufffdoVj\ufffdbaG\ufffd\ufffd\ufffd%\ufffdbýX\ufffd\ufffd\u001aG\ufffdY\ufffd\ufffd\u0005\ufffd\ufffd\u0003T\u0005",
+                "tt": 1
+              },
+              "\u0000\u0000\u0000\u0000\u0000\u0000\u0000'": {
+                "tb": "\ufffd\ufffd\ufffd\ufffd\u001c<\ufffdM\ufffd\ufffd\ufffd\ufffd\ufffd)Y\ufffd\ufffd\ufffd˳\ufffd|(\ufffd\ufffdHI\u0006\u001aڋP\b\ufffd綆\ufffdi+eK\ufffdK\\LP7\ufffdR\ufffdb\ufffd\ufffd\u0004m9/\ufffd\ufffd՝C\ufffdn퐏\ufffd=Hm\ufffd\ufffd\ufffd籫\ufffd:\ufffdp̻\ufffd\ufffd\ufffdM\u0014\ufffdSk\u0005c\u0005",
+                "tt": 1
+              },
+              "\u0000\u0000\u0000\u0000\u0000\u0000\u0000(": {
+                "tb": "\ufffdٷ̩,\ufffd\ufffdN\ufffdt\ufffdmp\ufffd<z\ufffd!\ufffdљ\ufffd\ufffdq<B\ufffdŚ\u0011\ufffdR\ufffd\ufffdH\t\ufffd\ufffd(\ufffda\ufffd\ufffd\ufffd{M5\u0016\ufffd\ufffdϚp\ufffdL1T/s\u0002\u0002}\ufffd\u000e\u0019\ufffdeY\ufffd\ufffd\ufffdy\ufffd\ufffd8`C\ufffdF\ufffd~ٰ\ufffd\u0011\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\\B",
+                "tt": 1
+              },
+              "\u0000\u0000\u0000\u0000\u0000\u0000\u0000)": {
+                "tb": "E\ufffd\ufffdk\ufffdэ\u0005%\u001e=\ufffdM\ufffd\u0010Zq\ufffd\f\ufffd\u0019\ufffd\rjh\ufffd\ufffd?\ufffd\ufffd\ufffd\ufffd($\b\tS7!\ufffd\ufffd\ufffdӻ\u0001\ufffd\u0018\ufffd\ufffd\ufffd\u001ek\ufffd\ufffdzd\ufffd\ufffd\t\ufffdH-J\ufffd\ufffd\ufffd\ufffd\u0012\ufffdh؆a㭵\u001d\ufffd\u0013\u0001\ufffd\ufffd\ufffd\ufffdݤV\ufffd\ufffd\ufffd)\ufffd\ufffd\u0007\ufffdA",
+                "tt": 1
+              },
+              "\u0000\u0000\u0000\u0000\u0000\u0000\u0000*": {
+                "tb": "s'<y\u0001\ufffdP`\ufffd\u001b?\ufffd\ufffdPuf\u0017e\ufffd\ufffd;\n\ufffd\u001c\ufffd\ufffd\ufffd\r\ufffd\ufffd`\ufffd\rt\u000e`\ufffd)\u0004\ufffd\ufffd\u0017\ufffd\ufffd\ufffdB\ufffd\ufffd\u0016n\ufffd\u0001\ufffd\ufffd\ufffdR\ufffd'\u001b/(K\u0005\ufffd>\ufffd\b2\u0004Ɨ׷\ufffd\ufffd\ufffd\ufffd\ufffdX\ufffdE\ufffd\u001d\u001d\f\ufffd\ufffd\ufffd\ufffd\u0006<\ufffd\ufffd\ufffd\ufffdc",
+                "tt": 1
+              },
+              "\u0000\u0000\u0000\u0000\u0000\u0000\u0000+": {
+                "tb": "v\ufffd)\ufffd\ufffd\ufffd\ufffd\u000e\ufffd#n\ufffd\u001eS\ufffd\ufffd\ufffd|LdjzɊ\ufffd\ufffd\u0019l\ufffd\u001cV \ufffdL\ufffd\ufffd?\ufffd$$,4HE\ufffd\ufffd\ufffdƪ\ufffdY\ufffdk#\ufffd\ufffd\nx\u0011\ufffdRؘ\ufffd\u0018\ufffd\ufffd\ufffd\ufffd\ufffd\u0012p\ufffd\ufffdh&\ufffd؊\ufffd+\ufffd\u0014\u001c\ufffd`x\u0007xGq\ufffdP6b",
+                "tt": 1
+              },
+              "\u0000\u0000\u0000\u0000\u0000\u0000\u0000,": {
+                "tb": "\ufffd U²\u0003]3\ufffdrĢ\ufffd%g\u0013\ufffd\ufffd\u00128\ufffdH\ufffdsw\ufffd'\ufffdG\u0002\ufffdwS\ufffdEN\ufffd\ufffdf'\f~\ufffd\ufffd\ufffdO\ufffd?,!\ufffd\ufffd\ufffdς2J\u0012D\ufffd_\u0004o\u0011{\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\n\ufffdޒa&\ufffd\ufffd\u001f\ufffd;\ufffd[?z\ufffd[r)\ufffd\ufffd\u0012\ufffd\ufffd\ufffd",
+                "tt": 1
+              },
+              "\u0000\u0000\u0000\u0000\u0000\u0000\u0000-": {
+                "tb": "5\ufffd\ufffd\ufffd\ufffdU\ufffd\u0011\ufffd\r\u0002\ufffd&\ufffdTY5e.\ufffd\ufffd\ufffdxxhІ\ufffd'\ufffd\ufffdͳw\ufffd蝬\ufffdj[ܓ\ufffd\u001f\ufffd\ufffd\u000be\ufffd\ufffd\ufffdl\ufffd\ufffdX\u0017\ufffd\u000e,\ufffd\u0017\ufffd\ufffd/M\ufffd\ufffd\ufffd\f\ufffd>}\bg:J6\ufffdS\ufffd+\ufffd\ufffd\ufffd\ufffd\ufffd&RW\ufffd\u0000|ٞ,",
+                "tt": 1
+              },
+              "\u0000\u0000\u0000\u0000\u0000\u0000\u0000.": {
+                "tb": "v\ufffdU\ufffd\ufffd\u0007\ufffd)\ufffdĵ\u00136?0\u001d$1\ufffdȇ-y\u0004<:\ufffd\b\ufffd\ufffd\ufffdy\ufffd\ufffd\ufffdI\ufffdnD\ufffd\ufffd\ufffdA\u0012\ufffdZje\u0006\u0003\ufffdb\ufffd\u0013\ufffd\u0000<A\ufffd\ufffdt\ufffdx\ufffd\r8\ufffd\u001em\ufffd\ufffd\ufffd&\ufffd\ufffd\ufffdU\ufffd\ufffd!\ufffd\u0013\ufffd\ufffd<\u001f\ufffdv\ufffd$(a\ufffd\u0005A",
+                "tt": 1
+              },
+              "\u0000\u0000\u0000\u0000\u0000\u0000\u0000/": {
+                "tb": "7\ufffd>*E\ufffd\ufffdr\ufffdBD\u0003)\u001c\ufffd\u0019\ufffdL\ufffd<\u0004\ufffd\b\u001a\ufffd\ufffdg\ufffd8E\ufffd\ufffdw\u0001ڔ}\ufffdH\u000fZ\ufffd\u0001\ufffdى\ufffd\ufffd\u001b\ufffd\ufffdxc^\ufffd\ufffd\ufffd~\u001f\ufffd\u0015H\ufffd\u000f\u0017d\ufffdP`1\u001c\ufffd\ufffd\ufffd[\ufffd$/5iHTR)\ufffdU\u001a1\u0000M\n\ufffd\ufffd\ufffd\ufffdf",
+                "tt": 1
+              },
+              "\u0000\u0000\u0000\u0000\u0000\u0000\u00000": {
+                "tb": "\ufffdl\ufffd$\ufffd0\ufffdɡXK:XUC\u0018\ufffd\b\ufffdy\ufffd\ufffd\ufffdnV\ufffd\ufffd\u0010\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\u0001\u0016ev_cPfs\ufffd\ufffdo\ufffd\ufffd\ufffdW\ufffd\ufffdhH\ufffd3\u000e\ufffd\ufffdj\u0013<2\ufffd48\ufffd4\ufffdJKV\u0004\ufffd\ufffd\ufffdIPRm\ufffd\ufffd\ufffd\ufffd\ufffdV\ufffdX\ufffd-\u0000OQ\n\ufffd\ufffd",
+                "tt": 1
+              },
+              "\u0000\u0000\u0000\u0000\u0000\u0000\u00001": {
+                "tb": "j\ufffd#\ufffd\ufffd\ufffd<\ufffd\ufffd\ufffd\u0000\ufffdV\ufffd\ufffd\u0011{\ufffdy\ufffd\ufffd\ufffd\u0003\ufffd%AS\u0013\u0004\ufffd\u0003I\u0003\ufffd\ufffd\ufffdM\ufffd\u001a@{\ufffd\ufffd\ufffd J\ufffd\ufffdmb\u0004ʖ\ufffd\u001e\ufffd\u0016\ufffd\ufffd\u001fX\ufffd\ufffd\ufffd\ufffd\u0019\ufffdŚ\ufffd\ufffd^\ufffd#\ufffd|\ufffd\u0015ⓒ\ufffd|M\u0014Y\ufffd\ufffd(UƔ\ufffdL\ufffd",
+                "tt": 1
+              },
+              "\u0000\u0000\u0000\u0000\u0000\u0000\u00002": {
+                "tb": "bx\u0000\ufffd\ufffd\u0006\ufffd7\ufffdgHU\u0007_\ufffdo\ufffd\u0011\ufffd\ufffdʇasEc\u0014\u0003\ufffd\u0018\ufffd,\ufffd\ufffd\ufffdu \ufffd\ufffdR\ufffdy\ufffdl7T\u001dQ~\ufffd\ufffd\ufffd\ufffd\ufffdY\ufffd\ufffd\ufffdu\ufffd\ufffd4\ufffd\u001a\ufffd\ufffd\ufffd\ufffd3\u0012\ufffd\ufffd\ufffdc\ufffd\ufffd\ufffd\ufffd'\ufffd\ufffd5ON)\ufffd\ufffd\ufffdh\u001d\ufffd\ufffd\ufffdG=",
+                "tt": 1
+              },
+              "\u0000\u0000\u0000\u0000\u0000\u0000\u00003": {
+                "tb": "f\ufffd\ufffd~\ufffd΅5\ufffdO\ufffd\ufffd\fw\ufffd\ufffdr\u0014\ufffdllZ~\ufffd\ufffd\u001e\ufffd\ufffd|#\ufffdxQ&^\ufffd\ufffdvU\ufffd\u0011\u0013\ufffdn\ufffdcm{\ufffd[\ufffd\u000f\ufffd\ufffd\ufffd\ufffd\u0010(\ufffd\ufffdƴň*\ufffd\ufffd\t\ufffd7\u0010\ufffdU\ufffd\ufffdP\ufffd\ufffd\ufffdp\ufffd'/\ufffd\u0003\ufffd\ufffd!*\u001dp\ufffd͐\ufffdn",
+                "tt": 1
+              },
+              "\u0000\u0000\u0000\u0000\u0000\u0000\u00004": {
+                "tb": "\u0019\ufffd\ufffdsaT\r\ufffd_Чh\u000e\u000b\ufffd\ufffd\ufffdj\ufffd\ufffdY\ufffd\ufffda\ufffd\ufffd\ufffdY\ufffd\ufffd\ufffdU\u0011\u001aI\ufffd\ufffd\ufffd4\ufffdK\u0019(\u001b5\ufffd\ufffd\ufffd0\ufffdg\ufffdqf\ufffdo\ufffd\ufffdr\u0003?\ufffdi\u0007\ufffd*ȼ\ufffd\ufffd?\ufffdK\ufffd1\ufffd*\ufffdùǴ:#\u0007Ԟ\ufffdh]\ufffd\ufffd\ufffd\u0002\u0018\ufffd",
+                "tt": 1
+              },
+              "\u0000\u0000\u0000\u0000\u0000\u0000\u00005": {
+                "tb": "=\ufffd\ufffd\n8\u0006\ufffdk4\ufffd\ufffdS\ufffd\ufffd\ufffd\ufffd\ufffdS\ufffd\ufffd_\u00054\ufffd\u0012\ufffd8\ufffd\ufffda\ufffd.\u0011֭h]\ufffd!\u000e\u000b\ufffd \ufffd4\r\ufffd\ufffd\\\ufffdX>\ufffd\ufffdΪ\ufffd\ufffds\ufffd\ufffd09&\u0001|?\ufffd_\ufffd\ufffd)\ufffd\ufffd:\ufffd\u0006\ufffdEuu\u0015\u001e\ufffd\ufffdL\ufffdq\ufffd\u000b\ufffd\ufffd\u000f\ufffd\ufffd\u000f",
+                "tt": 1
+              },
+              "\u0000\u0000\u0000\u0000\u0000\u0000\u00006": {
+                "tb": "\u0007N\ufffdh\ufffd\tQoHM\ufffd\ufffd\ufffdcڟ\u000f\u0010c\ufffd\ufffdA\ufffd\ufffd\ufffd\ufffd\u0013v\ufffd2A\ufffd\ufffdm\ufffd\ufffd\u0001\ufffd2\ufffdi`\u0010E-m!\ufffd\ufffdl\ufffd\ufffd\ufffd\ufffd<6.\u0014\ufffdq\ufffd\ufffdkhygH\ufffd\ufffdb\ufffd\ufffdy\ufffd\ufffd\ufffd_\ufffd\ufffd\u0018y$ׇ3\ufffdq\ufffd\ufffd\u0000ѕP5\u0011\ufffd",
+                "tt": 1
+              },
+              "\u0000\u0000\u0000\u0000\u0000\u0000\u00007": {
+                "tb": "\u000b%\ufffd$S:\ufffd\ufffd\ufffd\\\ufffd\ufffd\ufffdZ\ufffd\ufffdF\ufffd\ufffd\u0017\ufffd~]!\t\ufffdᴂ<\ufffd\ufffdv\"-2|\ufffdJk\ufffd\ufffdP8\u000fb\ufffd\ufffd\ufffd,PQ\u0000\u0011zy\ufffd\ufffd\u0006\ufffd\\H\ufffd±B\ufffdԍ\ufffdS\ufffdUK~\ufffd\ufffd_\ufffd\ufffdJs\u0012\ufffd\ufffd`\ufffd%V\ufffd)p\ufffd\t.",
+                "tt": 1
+              },
+              "\u0000\u0000\u0000\u0000\u0000\u0000\u00008": {
+                "tb": "\u000bR\ufffdbϰU\ufffd\ufffdg\ufffd\ufffdk\ufffd\u0010\ufffd\ufffd'Kf\ufffdQK\u0006p\u0003zb\ufffdρ\ufffd\ufffdh}\ufffdY\ufffdZMܱX\ufffd\ufffd\ufffd3\ufffd\ufffd9\ufffd\ufffd'N\u0000\u0014*ގ\n\ufffdx\u001c\u0000\u001fR\ufffdֵƏtM\ufffd\u0004\ufffd$\ufffd\ufffd,\ufffd\u0011\ufffd\ufffdDR92\ufffd\ufffd\ufffd\ufffd5Zt\ufffd",
+                "tt": 1
+              },
+              "\u0000\u0000\u0000\u0000\u0000\u0000\u00009": {
+                "tb": "~\ufffd̥\ufffdyf<YW\ufffdR-U\ufffd\ufffdd|6\ufffdG\ufffdF\ufffdQ\ufffdOh\ufffdy\ufffdg\ufffda-\u000ei\u0006\u000e\ufffd\ufffd1\ufffd^E\ufffd$\ufffd\ufffdO:Ҳ\u0000\ufffd\r\bb\ufffd\u0004W\ufffd\ufffd\ufffd\u0002\ufffdd\ufffdQ*0DY\ufffdя[\ufffd/\u0003\ufffd\ufffdG6\ufffdd[t\ufffdqx>\ufffd\\\ufffd\u000f",
+                "tt": 1
+              },
+              "\u0000\u0000\u0000\u0000\u0000\u0000\u0000:": {
+                "tb": "`\r\f\ufffd\ufffd!\ufffd\ufffdG:\ufffdl\ufffdL%<]\ufffdf\ufffd[\ufffd';a\ufffdv\ufffdqU\ufffd\ufffdU\ufffd<\ufffd\ufffd\ufffd\ufffd\ufffd=\ufffd\ufffdk8\u0018\ufffd6*\ufffd\ufffd\ufffd\ufffd\ufffd譻l\ufffdv\ufffdя\ufffd\ufffd\ufffd\ufffd\ufffd[\ufffd\ufffd\ufffd\u000eX7\n+\ufffd<f\ufffd\ufffd\ufffd\u0019\ufffdQQ(PT`\n$\u001d7+",
+                "tt": 1
+              },
+              "\u0000\u0000\u0000\u0000\u0000\u0000\u0000;": {
+                "tb": "\ufffd0ׅ\ufffd\ufffd\ufffdxJ\ufffdXf@?-\ufffd\u001f\ufffd\u0016\ufffdU\ufffd!Y:N\ufffd=\ufffdL\u0018 >g\ufffdq\ufffd\ufffd\ufffd\ufffdIJ\ufffd\ufffd)Zݙ\ufffd\ufffd@#\ufffd\ufffd\ufffd\ufffdN\ufffd\ufffd\ufffd:?\u0015o\ufffd\\\u0015\ufffd(\u000f\u0010p\ufffd\ufffd\ufffd\ufffd\ufffd!^\ufffdi\ufffdf\ufffd\ufffd\n\ufffd4t\ufffd\ufffd\ufffd\ufffd\ufffd\u0015\ufffd",
+                "tt": 1
+              },
+              "\u0000\u0000\u0000\u0000\u0000\u0000\u0000<": {
+                "tb": "e\ufffd\ufffd0\ufffdKmH:\u0003\ufffdN0\ufffd\ufffd\ufffd\ufffd5\ufffd\ufffd\ufffd\u001d\ufffd5D\b\ufffd Y\ufffd\ufffdG]&k\ufffdr\u0014W\u0002!\ufffdP\ufffdᡒu\ufffd\ufffd\ufffd\u001b\ufffd\ufffde\u00062`\ufffd\u001a\u0012F\ufffd\ufffd\ufffd\ufffdJ\u001dx.\ufffd\nH3\ufffdP˜\ufffd\ufffdJ\ufffd\b1\u001a뷖@r\r\ufffd`\ufffd\ufffd",
+                "tt": 1
+              },
+              "\u0000\u0000\u0000\u0000\u0000\u0000\u0000=": {
+                "tb": "\ufffd\ufffd;\r\u0004\u0014\ufffde\ufffd*$\ufffdf؝\u001b\ufffda\ufffdH\ufffdtQ\ufffd\u0001\ufffd\ufffd}\ufffd\ufffd\ufffd\u0000\ufffd\ufffdd\u0014|\ufffd{t\ufffd\ufffd\ufffd\ufffdh^\u0018\ufffd/`a\u001aRÆh\ufffd\u0007\u0002:\ufffd\ufffd\u0013\ufffd\ufffd\ufffd\ufffd\ufffd![p\ufffd\ufffd gZ\ufffdrw\ufffd\u0005\ufffd4\ufffd갉[PC[\u000f:48\u001b",
+                "tt": 1
+              },
+              "\u0000\u0000\u0000\u0000\u0000\u0000\u0000>": {
+                "tb": "4\t\ufffdg\ufffd\ufffd\ufffd\ufffd.eb\ufffd\b\ufffd\ufffd\ufffdb4[,\ufffd\ufffd\u0015\ufffd3\ufffd\ufffd\ufffdM\ufffd\ufffd\ufffd\ufffdL:$Ы\ufffdM\ufffd\ufffd\ufffd\u000f\ufffd\ufffd(\ufffd\ufffd\ufffd\ufffdM\ufffd\ufffd\ufffd;œ\fi\ufffdv\ufffd\ufffd3\ufffdS\ufffd\u00036\ufffd\ufffd#9\u0016\u0005.\ufffdo\u0000\ufffd1\u001eZ9\ufffd\ufffd{b;\u0016\u000bO",
+                "tt": 1
+              }
+            },
+            "gsch": {
+              "nbs": 64
+            }
+          }
+        },
+        "State": {
+          "Deleted": false,
+          "LocalState": null
+        }
+      },
+      {
+        "Addr": "OOADCJDVTA3QKWLBI7QBQZVTXXOVNYY4RMXNLAQNPQGTNK7Y446SX5MFCM",
+        "Aidx": 92138200,
+        "Params": {
+          "Deleted": false,
+          "Params": null
+        },
+        "State": {
+          "Deleted": false,
+          "LocalState": {
+            "hsch": {
+              "nbs": 16
+            },
+            "tkv": {
+              "\f": {
+                "tb": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+                "tt": 1
+              },
+              "\r": {
+                "tb": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+                "tt": 1
+              },
+              "\u000e": {
+                "tb": "\u0000\u0000\u0000\u0000\u0000\u0004\f/S\u0000\u0000\u0000\u0000\u0000\u0000$\ufffd\u0000\u0000\u0000\u0000\u0000\u000fB@P9\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0003\ufffdIS\u0000\u0000\u0000\u0000\u0000\u0000)\u000e\u0000\u0000\u0000\u0000\u0000\u000fB@P;\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+                "tt": 1
+              },
+              "accountInfo": {
+                "tb": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001\ufffd\ufffd\u0000\u0000\u0000\u0000\u0000\u001e\ufffd\ufffd\u0000\u0000\u0000\u0000\u0000\u000fB@\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\n\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd",
+                "tt": 1
+              }
+            }
+          }
+        }
+      },
+      {
+        "Addr": "KHKO4BLTFEHRXECEGCPRYOEHFZQVYAFOQSV5O2XUHQ7HHDKKZ7OZNQEEAA",
+        "Aidx": 92138200,
+        "Params": {
+          "Deleted": false,
+          "Params": null
+        },
+        "State": {
+          "Deleted": false,
+          "LocalState": {
+            "hsch": {
+              "nbs": 16
+            },
+            "tkv": {
+              "\u000e": {
+                "tb": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0004\ufffd\ufffdS\u0000\u0000\u0000\u0000\u0000\u0000\"\ufffd\u0000\u0000\u0000\u00009\n\ufffd@0<",
+                "tt": 1
+              },
+              "accountInfo": {
+                "tb": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\ufffd,6\u0000\u0000\u0000\u00009\n\ufffd@\u0000\u0000\u0000\u0000X\ufffd_@\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0007\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd",
+                "tt": 1
+              }
+            }
+          }
+        }
+      }
+    ],
+    "AssetResources": null
+  },
+  "Creatables": null,
+  "Hdr": {
+    "earn": 27521,
+    "fees": "A7NMWS3NT3IUDMLVO26ULGXGIIOUQ3ND2TXSER6EBGRZNOBOUIQXHIBGDE",
+    "frac": 2047917429,
+    "gen": "testnet-v1.0",
+    "gh": "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=",
+    "prev": "blk-DGCK2OZX73HENEQ36UAYH6NUQIBCBKHJKHZHP4GXI7HCZH3BMRIA",
+    "proto": "https://github.com/algorandfoundation/specs/tree/44fa607d6051730f5264526bf3c108d51f0eadb6",
+    "rate": 42,
+    "rnd": 26910002,
+    "rwcalr": 27000000,
+    "rwd": "7777777777777777777777777777777777777777777777777774MSJUVU",
+    "seed": "y7GjtZVwK0PU7gD97SS6cv1J8l1H4v5IDhHaCfiDZmE=",
+    "spt": {
+      "0": {
+        "n": 26909952
+      }
+    },
+    "tc": 153348361,
+    "ts": 1673397875,
+    "txn": "etVItYGArmk1FadXoNyxuByy7m/ZjqCOjajjaTbPZeQ=",
+    "txn256": "dGZhFIv+P0DfDXKtIVbKjocOruYTT+0CQLp+QeXQWv0="
+  },
+  "KvMods": null,
+  "PrevTimestamp": 1673397871,
+  "StateProofNext": 0,
+  "Totals": {
+    "notpart": {
+      "mon": 347207141836,
+      "rwd": 346468
+    },
+    "offline": {
+      "mon": 2544590110565384,
+      "rwd": 2526267564
+    },
+    "online": {
+      "mon": 7580062682392780,
+      "rwd": 7580062232
+    },
+    "rwdlvl": 27521
+  },
+  "Txids": {
+    "/36ndb8DIXo31AlKm9yVZonyMpOw/M1UuHuxr3bwgmk=": {
+      "Intra": 5,
+      "LastValid": 26911001
+    },
+    "3Avuu0SuuR40vimeFxrWvYKJVbch/0LZtqAxyqQiII0=": {
+      "Intra": 2,
+      "LastValid": 26911001
+    },
+    "5uxu3WRlSyQD8dyig27fQGtBMKOtHkSEkVyHE8Z6ra0=": {
+      "Intra": 4,
+      "LastValid": 26911001
+    },
+    "6Pmo1Y4YW1AZ1d+wpf5iHxC3zXkiyxAaZPKinfDe5UQ=": {
+      "Intra": 6,
+      "LastValid": 26911001
+    },
+    "7xsQOaCffOtmtaXSFpYfsLoWY/2xElSgTzohK1Q5XPs=": {
+      "Intra": 8,
+      "LastValid": 26911001
+    },
+    "A0nBcRzofiWuepCuzk7usKOGdmtp5E+Ku2CqlpMPjms=": {
+      "Intra": 0,
+      "LastValid": 26910989
+    },
+    "CBqkqJVJ4jqe6Su5dKPkpinxZHCxtYEiKAH9i8s1v+Q=": {
+      "Intra": 3,
+      "LastValid": 26911001
+    },
+    "ES20PzakDP3UBZnd8Cydrgu6P6/SxbJKzh5O2IEvpb0=": {
+      "Intra": 9,
+      "LastValid": 26911001
+    },
+    "Vkp8mVWLQFrQCQlVXRzSmuBRuVGOORPK5W2tAJz4/d4=": {
+      "Intra": 1,
+      "LastValid": 26911001
+    },
+    "ljiCUgifBagW+8eFi2K0GPa+X13uJJPQLeOnK1M79Y8=": {
+      "Intra": 7,
+      "LastValid": 26911001
+    }
+  },
+  "Txleases": null
+}

--- a/features/resources/v2algodclient_responsejsons/statedelta_testnet_26091003.json
+++ b/features/resources/v2algodclient_responsejsons/statedelta_testnet_26091003.json
@@ -1,0 +1,139 @@
+{
+  "Accts": {
+    "Accts": [
+      {
+        "Addr": "7777777777777777777777777777777777777777777777777774MSJUVU",
+        "AuthAddr": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ",
+        "MicroAlgos": 2051818321,
+        "RewardedMicroAlgos": 0,
+        "RewardsBase": 0,
+        "SelectionID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "StateProofID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "Status": 2,
+        "TotalAppLocalStates": 0,
+        "TotalAppParams": 0,
+        "TotalAppSchema": {},
+        "TotalAssetParams": 0,
+        "TotalAssets": 0,
+        "TotalBoxBytes": 0,
+        "TotalBoxes": 0,
+        "TotalExtraAppPages": 0,
+        "VoteFirstValid": 0,
+        "VoteID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "VoteKeyDilution": 0,
+        "VoteLastValid": 0
+      },
+      {
+        "Addr": "UKSBQH6FOHPZMEQ7YPDSD3AV54XSXRFG744W6WF4QUFEF5SLXVIL7SQ4GM",
+        "AuthAddr": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ",
+        "MicroAlgos": 295200,
+        "RewardedMicroAlgos": 0,
+        "RewardsBase": 27521,
+        "SelectionID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "StateProofID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "Status": 0,
+        "TotalAppLocalStates": 0,
+        "TotalAppParams": 0,
+        "TotalAppSchema": {},
+        "TotalAssetParams": 0,
+        "TotalAssets": 0,
+        "TotalBoxBytes": 0,
+        "TotalBoxes": 0,
+        "TotalExtraAppPages": 0,
+        "VoteFirstValid": 0,
+        "VoteID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "VoteKeyDilution": 0,
+        "VoteLastValid": 0
+      },
+      {
+        "Addr": "A7NMWS3NT3IUDMLVO26ULGXGIIOUQ3ND2TXSER6EBGRZNOBOUIQXHIBGDE",
+        "AuthAddr": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ",
+        "MicroAlgos": 342106549750,
+        "RewardedMicroAlgos": 0,
+        "RewardsBase": 0,
+        "SelectionID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "StateProofID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "Status": 2,
+        "TotalAppLocalStates": 0,
+        "TotalAppParams": 0,
+        "TotalAppSchema": {},
+        "TotalAssetParams": 0,
+        "TotalAssets": 0,
+        "TotalBoxBytes": 0,
+        "TotalBoxes": 0,
+        "TotalExtraAppPages": 0,
+        "VoteFirstValid": 0,
+        "VoteID": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "VoteKeyDilution": 0,
+        "VoteLastValid": 0
+      }
+    ],
+    "AppResources": null,
+    "AssetResources": null
+  },
+  "Creatables": null,
+  "Hdr": {
+    "earn": 27521,
+    "fees": "A7NMWS3NT3IUDMLVO26ULGXGIIOUQ3ND2TXSER6EBGRZNOBOUIQXHIBGDE",
+    "frac": 2047917471,
+    "gen": "testnet-v1.0",
+    "gh": "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=",
+    "prev": "blk-5TF3YYGCEP3F5Y67LS4QND6GO2J3LROT3JYVCJBULDWQC3KIPATA",
+    "proto": "https://github.com/algorandfoundation/specs/tree/44fa607d6051730f5264526bf3c108d51f0eadb6",
+    "rate": 42,
+    "rnd": 26910003,
+    "rwcalr": 27000000,
+    "rwd": "7777777777777777777777777777777777777777777777777774MSJUVU",
+    "seed": "cTBVGCaNSy6lpFHEZC/wogPmDeNM7PCUliLQl+HEjH4=",
+    "spt": {
+      "0": {
+        "n": 26909952
+      }
+    },
+    "tc": 153348366,
+    "ts": 1673397878,
+    "txn": "7t4+E0Vhj47kfCrg1PUvDeBffSPhp86wUuI4kBsCjls=",
+    "txn256": "2EoaVSWHtOTfTf/5g88WppeKdTPtIcMx7wc+nHm1OyM="
+  },
+  "KvMods": null,
+  "PrevTimestamp": 1673397875,
+  "StateProofNext": 0,
+  "Totals": {
+    "notpart": {
+      "mon": 347207146836,
+      "rwd": 346468
+    },
+    "offline": {
+      "mon": 2544590110560384,
+      "rwd": 2526267564
+    },
+    "online": {
+      "mon": 7580062682392780,
+      "rwd": 7580062232
+    },
+    "rwdlvl": 27521
+  },
+  "Txids": {
+    "582J5rzaCICaxgGnKz0WiCIB5kpB8krGHZX/W6Bd8dY=": {
+      "Intra": 4,
+      "LastValid": 26910007
+    },
+    "DXMq5UdOubNb2b/CtSv+3i2Sk+/lFY/Kmg0E9P+wlEc=": {
+      "Intra": 1,
+      "LastValid": 26910007
+    },
+    "VH47fPqBWEnB3q0U0/kTcJCpC3VlkCTYer39o8xwlvE=": {
+      "Intra": 2,
+      "LastValid": 26910007
+    },
+    "tLiR0xUwx2TpaWCP8q6ycBZqtiGWoUUFdFSmVETieYs=": {
+      "Intra": 3,
+      "LastValid": 26910007
+    },
+    "vVLDNK8yxToHiFKuS4CqscfA59+jyppclzD9zX9+sIc=": {
+      "Intra": 0,
+      "LastValid": 26910007
+    }
+  },
+  "Txleases": null
+}

--- a/features/unit/responses.feature
+++ b/features/unit/responses.feature
@@ -212,7 +212,7 @@ Feature: REST Client Responses
 
     @unit.responses.txngroupdeltas
     Examples:
-      | jsonfile                           | response-folder             | status | client | endpoint                                    |
+      | jsonfile                           | response-folder     | status | client | endpoint                                    |
       | groupdelta-betanet_23963123.base64 | generated_responses | 200    | algod  | GetTransactionGroupLedgerStateDeltaForRound |
 
     @unit.responses.txngroupdeltas
@@ -221,3 +221,24 @@ Feature: REST Client Responses
       | groupdelta-betanet_23963123_0.base64 | generated_responses | 200    | algod  | GetLedgerStateDeltaForTransactionGroup |
       | groupdelta-betanet_23963123_1.base64 | generated_responses | 200    | algod  | GetLedgerStateDeltaForTransactionGroup |
       | groupdelta-betanet_23963123_1.base64 | generated_responses | 200    | algod  | GetLedgerStateDeltaForTransactionGroup |
+
+    @unit.responses.txngroupdeltas.json
+    Examples:
+      | jsonfile                           | response-folder             | status | client | endpoint                               |
+      | groupdelta-betanet_23963123_0.json | v2algodclient_responsejsons | 200    | algod  | GetLedgerStateDeltaForTransactionGroup |
+      | groupdelta-betanet_23963123_1.json | v2algodclient_responsejsons | 200    | algod  | GetLedgerStateDeltaForTransactionGroup |
+      | groupdelta-betanet_23963123_2.json | v2algodclient_responsejsons | 200    | algod  | GetLedgerStateDeltaForTransactionGroup |
+
+    @unit.responses.txngroupdeltas.json
+    Examples:
+      | jsonfile                         | response-folder             | status | client | endpoint                                    |
+      | groupdelta-betanet_23963123.json | v2algodclient_responsejsons | 200    | algod  | GetTransactionGroupLedgerStateDeltaForRound |
+
+    @unit.responses.statedelta.json
+    Examples:
+      | jsonfile                         | response-folder     | status | client | endpoint            |
+      | statedelta_betanet_22085518.json | v2algodclient_responsejsons | 200    | algod  | GetLedgerStateDelta |
+      | statedelta_testnet_26091000.json | v2algodclient_responsejsons | 200    | algod  | GetLedgerStateDelta |
+      | statedelta_testnet_26091001.json | v2algodclient_responsejsons | 200    | algod  | GetLedgerStateDelta |
+      | statedelta_testnet_26091002.json | v2algodclient_responsejsons | 200    | algod  | GetLedgerStateDelta |
+      | statedelta_testnet_26091003.json | v2algodclient_responsejsons | 200    | algod  | GetLedgerStateDelta |


### PR DESCRIPTION
Two things in this PR

1. Adds json response tests for txn group deltas. Because of the issues w/ the json msgp decoder, we've decided to use the json response format in the JS SDK. This adds response tests for that under a new test tag.
2. Because of the recent sandbox changes we're now using conduit/indexer to ingest data from dev mode algod. It seems like this introduces slightly more delay in retrying block gets because there are some failures retrieving data in the application tests after the `500` millisecond sleeps. See [this go-algorand-sdk test run](https://app.circleci.com/pipelines/github/algorand/go-algorand-sdk/1020/workflows/e0d34709-a0b6-4050-89de-44e248ae3a19/jobs/2382) for example. I've double the wait time to ensure data propagates before the test runs.