### PR TITLE
bug: Fix accountinfo response

### DIFF
--- a/features/resources/v2algodclient_responsejsons/accountInformation.json
+++ b/features/resources/v2algodclient_responsejsons/accountInformation.json
@@ -8,5 +8,6 @@
   "status" : "Not Participating",
   "round" : 6222133,
   "reward-base" : 0,
-  "rewards" : 0
+  "rewards" : 0,
+  "min-balance": 1000
 }

--- a/features/resources/v2algodclient_responsejsons/accountInformation.json
+++ b/features/resources/v2algodclient_responsejsons/accountInformation.json
@@ -9,5 +9,9 @@
   "round" : 6222133,
   "reward-base" : 0,
   "rewards" : 0,
+  "total-apps-opted-in": 0,
+  "total-assets-opted-in": 0,
+  "total-created-apps": 0,
+  "total-created-assets": 0,
   "min-balance": 1000
 }

--- a/features/unit/v2algodclient_responsejsons/accountInformation.json
+++ b/features/unit/v2algodclient_responsejsons/accountInformation.json
@@ -8,5 +8,6 @@
   "status" : "Not Participating",
   "round" : 6222133,
   "reward-base" : 0,
-  "rewards" : 0
+  "rewards" : 0,
+  "min-balance": 1000
 }

--- a/features/unit/v2algodclient_responsejsons/accountInformation.json
+++ b/features/unit/v2algodclient_responsejsons/accountInformation.json
@@ -9,5 +9,9 @@
   "round" : 6222133,
   "reward-base" : 0,
   "rewards" : 0,
+  "total-apps-opted-in": 0,
+  "total-assets-opted-in": 0,
+  "total-created-apps": 0,
+  "total-created-assets": 0,
   "min-balance": 1000
 }


### PR DESCRIPTION
The AccountInfo response that is provided does not provide some fields which are marked as required in the spec which causes errors when trying to decode this into an object in the JS SDK tests.