### PR TITLE
Set min balance field to zero

### DIFF
--- a/features/resources/v2algodclient_responsejsons/accountInformation.json
+++ b/features/resources/v2algodclient_responsejsons/accountInformation.json
@@ -13,5 +13,5 @@
   "total-assets-opted-in": 0,
   "total-created-apps": 0,
   "total-created-assets": 0,
-  "min-balance": 1000
+  "min-balance": 0
 }

--- a/features/unit/v2algodclient_responsejsons/accountInformation.json
+++ b/features/unit/v2algodclient_responsejsons/accountInformation.json
@@ -13,5 +13,5 @@
   "total-assets-opted-in": 0,
   "total-created-apps": 0,
   "total-created-assets": 0,
-  "min-balance": 1000
+  "min-balance": 0
 }


### PR DESCRIPTION
Our Go and Java SDKs do not define a `min-balance` field, so it leads to [failed tests](https://app.circleci.com/pipelines/github/algorand/go-algorand-sdk/1077/workflows/9f5dc9a6-839a-4ff2-8400-21cb523c6c8c/jobs/2447). Related ticket here: https://github.com/algorand/go-algorand-sdk/issues/272

This PR sets the field to zero to make sure existing SDK tests still pass.