### PR TITLE
Simulate: Execution trace with state changes and hash of executed bytecode

### DIFF
--- a/features/integration/simulate.feature
+++ b/features/integration/simulate.feature
@@ -205,3 +205,23 @@ Feature: Simulating transactions
     Then 4th unit in the "approval" trace at txn-groups path "0" should add value "uint64:1" to stack, pop 2 values from stack, write value "" to scratch slot "".
     Then 29th unit in the "approval" trace at txn-groups path "0" should add value "bytes:MSE=,bytes:NSE=" to stack, pop 0 values from stack, write value "" to scratch slot "".
     Then 31th unit in the "approval" trace at txn-groups path "0" should add value "" to stack, pop 1 values from stack, write value "uint64:18446744073709551615" to scratch slot "1".
+
+  @simulate.exec_trace_with_state_change_and_hash
+  Scenario: Simulate app with response containing state changes and hash of executed byte code
+  Given a new AtomicTransactionComposer
+    When I build an application transaction with the transient account, the current application, suggested params, operation "create", approval-program "programs/state-changes.teal", clear-program "programs/eight.teal", global-bytes 0, global-ints 0, local-bytes 0, local-ints 0, app-args "", foreign-apps "", foreign-assets "", app-accounts "", extra-pages 0, boxes ""
+    And I sign and submit the transaction, saving the txid. If there is an error it is "".
+    And I wait for the transaction to be confirmed.
+    Given I remember the new application ID.
+
+    Given I add the nonce "simulate-with-exec-trace-state-changes"
+    When I make a new simulate request.
+    When I create the Method object from method signature "local()void"
+    * I create a new method arguments array.
+    * I add a nonced method call with the transient account, the current application, suggested params, on complete "noop", current transaction signer, current method arguments.
+
+    Then I allow exec trace options "stack,scratch" on that simulate request.
+    Then I simulate the transaction group with the simulate request.
+    And the simulation should succeed without any failure message
+
+    # TODO

--- a/features/integration/simulate.feature
+++ b/features/integration/simulate.feature
@@ -213,22 +213,23 @@ Feature: Simulating transactions
     And I sign and submit the transaction, saving the txid. If there is an error it is "".
     And I wait for the transaction to be confirmed.
     Given I remember the new application ID.
+    And I fund the current application's address with 1000000 microalgos.
 
-    Given I add the nonce "simulate-with-exec-trace-state-changes"
     When I make a new simulate request.
     When I create the Method object from method signature "<method>"
     And I create a new method arguments array.
-    And I add a nonced method call with the transient account, the current application, suggested params, on complete "noop", current transaction signer, current method arguments.
+    And I add a method call with the transient account, the current application, suggested params, on complete "noop", current transaction signer, current method arguments, boxes "0,str:box-key-1,0,str:box-key-2".
 
     Then I allow exec trace options "state" on that simulate request.
     And I simulate the transaction group with the simulate request.
     And the simulation should succeed without any failure message
 
-    Then "approval" hash at txn-groups path "0" should be "4NiVKyKI3huK1nHi/etuy5rbgnP1ODRaN77WF2swNNY=".
+    Then "approval" hash at txn-groups path "0" should be "elIoqp1XgWrLCBLPmaZlDsKE3sEMZBY1dlxOvBXPtak=".
     And <index1>th unit in the "approval" trace at txn-groups path "0" should write to "<state>" state "<key1>" with new value "<value1>".
     And <index2>th unit in the "approval" trace at txn-groups path "0" should write to "<state>" state "<key2>" with new value "<value2>".
 
     Examples:
-      | method       | state  | index1 | key1           | value1            | index2 | key2             | value2                     |
-      | global()void | global | 13     | global-int-key | uint64:3735928559 | 16     | global-bytes-key | bytes:d2VsdCBhbSBkcmFodA== |
-      | local()void  | local  | 14     | local-int-key  | uint64:3405689018 | 18     | local-bytes-key  | bytes:eHFjTA==             |
+      | method       | state  | index1 | key1           | value1                 | index2 | key2             | value2                     |
+      | global()void | global | 14     | global-int-key | uint64:3735928559      | 17     | global-bytes-key | bytes:d2VsdCBhbSBkcmFodA== |
+      | local()void  | local  | 15     | local-int-key  | uint64:3405689018      | 19     | local-bytes-key  | bytes:eHFjTA==             |
+      | box()void    | box    | 14     | box-key-1      | bytes:Ym94LXZhbHVlLTE= | 17     | box-key-2        | bytes:                     |

--- a/features/integration/simulate.feature
+++ b/features/integration/simulate.feature
@@ -216,7 +216,7 @@ Feature: Simulating transactions
     And I fund the current application's address with 1000000 microalgos.
 
     When I make a new simulate request.
-    When I create the Method object from method signature "<method>"
+    And I create the Method object from method signature "<method>"
     And I create a new method arguments array.
     And I add a method call with the transient account, the current application, suggested params, on complete "noop", current transaction signer, current method arguments, boxes "0,str:box-key-1,0,str:box-key-2".
 
@@ -224,9 +224,28 @@ Feature: Simulating transactions
     And I simulate the transaction group with the simulate request.
     And the simulation should succeed without any failure message
 
+    Then the current application initial "<state>" state should be empty.
+
     Then "approval" hash at txn-groups path "0" should be "elIoqp1XgWrLCBLPmaZlDsKE3sEMZBY1dlxOvBXPtak=".
     And <index1>th unit in the "approval" trace at txn-groups path "0" should write to "<state>" state "<key1>" with new value "<value1>".
     And <index2>th unit in the "approval" trace at txn-groups path "0" should write to "<state>" state "<key2>" with new value "<value2>".
+
+    # Submit the group to the actual network
+    Then I execute the current transaction group with the composer.
+    
+    # Simulate again so we can check the reported initial state.
+    Given a new AtomicTransactionComposer
+    When I make a new simulate request.
+    And I create the Method object from method signature "<method>"
+    And I create a new method arguments array.
+    And I add a method call with the transient account, the current application, suggested params, on complete "noop", current transaction signer, current method arguments, boxes "0,str:box-key-1,0,str:box-key-2,0,str:nonce-box".
+    
+    Then I allow exec trace options "state" on that simulate request.
+    And I simulate the transaction group with the simulate request.
+    And the simulation should succeed without any failure message
+
+    Then the current application initial "<state>" state should contain "<key1>" with value "<value1>".
+    And the current application initial "<state>" state should contain "<key2>" with value "<value2>".
 
     Examples:
       | method       | state  | index1 | key1           | value1                 | index2 | key2             | value2                     |

--- a/features/integration/simulate.feature
+++ b/features/integration/simulate.feature
@@ -209,19 +209,21 @@ Feature: Simulating transactions
   @simulate.exec_trace_with_state_change_and_hash
   Scenario: Simulate app with response containing state changes and hash of executed byte code
   Given a new AtomicTransactionComposer
-    When I build an application transaction with the transient account, the current application, suggested params, operation "create", approval-program "programs/state-changes.teal", clear-program "programs/eight.teal", global-bytes 0, global-ints 0, local-bytes 0, local-ints 0, app-args "", foreign-apps "", foreign-assets "", app-accounts "", extra-pages 0, boxes ""
+    When I build an application transaction with the transient account, the current application, suggested params, operation "create", approval-program "programs/state-changes.teal", clear-program "programs/eight.teal", global-bytes 1, global-ints 1, local-bytes 1, local-ints 1, app-args "", foreign-apps "", foreign-assets "", app-accounts "", extra-pages 0, boxes ""
     And I sign and submit the transaction, saving the txid. If there is an error it is "".
     And I wait for the transaction to be confirmed.
     Given I remember the new application ID.
 
     Given I add the nonce "simulate-with-exec-trace-state-changes"
     When I make a new simulate request.
-    When I create the Method object from method signature "local()void"
+    When I create the Method object from method signature "global()void"
     * I create a new method arguments array.
     * I add a nonced method call with the transient account, the current application, suggested params, on complete "noop", current transaction signer, current method arguments.
 
-    Then I allow exec trace options "stack,scratch" on that simulate request.
+    Then I allow exec trace options "state" on that simulate request.
     Then I simulate the transaction group with the simulate request.
     And the simulation should succeed without any failure message
 
-    # TODO
+    Then "approval" hash at txn-groups path "0" should be "4NiVKyKI3huK1nHi/etuy5rbgnP1ODRaN77WF2swNNY=".
+    Then 13th unit in the "approval" trace at txn-groups path "0" should write to "global" state "global-int-key" with new value "uint64:3735928559".
+    Then 16th unit in the "approval" trace at txn-groups path "0" should write to "global" state "global-bytes-key" with new value "bytes:d2VsdCBhbSBkcmFodA==".

--- a/features/integration/simulate.feature
+++ b/features/integration/simulate.feature
@@ -207,23 +207,28 @@ Feature: Simulating transactions
     Then 31th unit in the "approval" trace at txn-groups path "0" should add value "" to stack, pop 1 values from stack, write value "uint64:18446744073709551615" to scratch slot "1".
 
   @simulate.exec_trace_with_state_change_and_hash
-  Scenario: Simulate app with response containing state changes and hash of executed byte code
-  Given a new AtomicTransactionComposer
-    When I build an application transaction with the transient account, the current application, suggested params, operation "create", approval-program "programs/state-changes.teal", clear-program "programs/eight.teal", global-bytes 1, global-ints 1, local-bytes 1, local-ints 1, app-args "", foreign-apps "", foreign-assets "", app-accounts "", extra-pages 0, boxes ""
+  Scenario Outline: Simulate app with response containing state changes and hash of executed byte code
+    Given a new AtomicTransactionComposer
+    When I build an application transaction with the transient account, the current application, suggested params, operation "create-and-optin", approval-program "programs/state-changes.teal", clear-program "programs/eight.teal", global-bytes 1, global-ints 1, local-bytes 1, local-ints 1, app-args "", foreign-apps "", foreign-assets "", app-accounts "", extra-pages 0, boxes ""
     And I sign and submit the transaction, saving the txid. If there is an error it is "".
     And I wait for the transaction to be confirmed.
     Given I remember the new application ID.
 
     Given I add the nonce "simulate-with-exec-trace-state-changes"
     When I make a new simulate request.
-    When I create the Method object from method signature "global()void"
-    * I create a new method arguments array.
-    * I add a nonced method call with the transient account, the current application, suggested params, on complete "noop", current transaction signer, current method arguments.
+    When I create the Method object from method signature "<method>"
+    And I create a new method arguments array.
+    And I add a nonced method call with the transient account, the current application, suggested params, on complete "noop", current transaction signer, current method arguments.
 
     Then I allow exec trace options "state" on that simulate request.
-    Then I simulate the transaction group with the simulate request.
+    And I simulate the transaction group with the simulate request.
     And the simulation should succeed without any failure message
 
     Then "approval" hash at txn-groups path "0" should be "4NiVKyKI3huK1nHi/etuy5rbgnP1ODRaN77WF2swNNY=".
-    Then 13th unit in the "approval" trace at txn-groups path "0" should write to "global" state "global-int-key" with new value "uint64:3735928559".
-    Then 16th unit in the "approval" trace at txn-groups path "0" should write to "global" state "global-bytes-key" with new value "bytes:d2VsdCBhbSBkcmFodA==".
+    And <index1>th unit in the "approval" trace at txn-groups path "0" should write to "<state>" state "<key1>" with new value "<value1>".
+    And <index2>th unit in the "approval" trace at txn-groups path "0" should write to "<state>" state "<key2>" with new value "<value2>".
+
+    Examples:
+      | method       | state  | index1 | key1           | value1            | index2 | key2             | value2                     |
+      | global()void | global | 13     | global-int-key | uint64:3735928559 | 16     | global-bytes-key | bytes:d2VsdCBhbSBkcmFodA== |
+      | local()void  | local  | 14     | local-int-key  | uint64:3405689018 | 18     | local-bytes-key  | bytes:eHFjTA==             |

--- a/features/resources/programs/state-changes.teal
+++ b/features/resources/programs/state-changes.teal
@@ -9,8 +9,9 @@ bnz end // Always allow optin
 
 method "local()void"
 method "global()void"
+method "box()void"
 txn ApplicationArgs 0
-match local global
+match local global box
 err // Unknown command
 
 local:
@@ -32,6 +33,14 @@ global:
   byte "welt am draht"
   app_global_put
   b end
+
+box:
+  byte "box-key-1"
+  byte "box-value-1"
+  box_put
+  byte "box-key-2"
+  byte ""
+  box_put
 
 end:
   int 1

--- a/features/resources/programs/state-changes.teal
+++ b/features/resources/programs/state-changes.teal
@@ -1,0 +1,37 @@
+#pragma version 8
+txn ApplicationID
+bz end // Do nothing during create
+
+txn OnCompletion
+int OptIn
+==
+bnz end // Always allow optin
+
+method "local()void"
+method "global()void"
+txn ApplicationArgs 0
+match local global
+err // Unknown command
+
+local:
+  txn Sender
+  byte "local-int-key"
+  int 0xcafeb0ba
+  app_local_put
+  int 0
+  byte "local-bytes-key"
+  byte "xqcL"
+  app_local_put
+  b end
+
+global:
+  byte "global-int-key"
+  int 0xdeadbeef
+  app_global_put
+  byte "global-bytes-key"
+  byte "welt am draht"
+  app_global_put
+  b end
+
+end:
+  int 1


### PR DESCRIPTION
Adds support for testing the following new simulate features:
* algorand/go-algorand#5658
* algorand/go-algorand#5659
* algorand/go-algorand#5686

See https://github.com/algorand/js-algorand-sdk/pull/818 for test implementation