### PR TITLE
Algod: Config max account lookback

### DIFF
--- a/.env
+++ b/.env
@@ -26,7 +26,7 @@ CONDUIT_SHA=""
 
 # Sandbox configuration:
 SANDBOX_URL="https://github.com/algorand/sandbox"
-SANDBOX_BRANCH="master"
+SANDBOX_BRANCH="config-max-account-lookback"
 SANDBOX_CLEAN_CACHE=1
 LOCAL_SANDBOX_DIR=".sandbox"
 

--- a/.env
+++ b/.env
@@ -16,6 +16,7 @@ ALGOD_SHA=""
 NETWORK_TEMPLATE="images/algod/DevModeNetwork.json"  # refers to the ./images directory in the sandbox repo
 NETWORK_NUM_ROUNDS=30000
 NODE_ARCHIVAL="False"
+MAX_ACCOUNT_LOOKBACK=4
 INDEXER_URL="https://github.com/algorand/indexer"
 INDEXER_BRANCH="main" # sandbox no longer supports the pre-refactor code currently in master.
 INDEXER_SHA=""

--- a/.env
+++ b/.env
@@ -26,7 +26,7 @@ CONDUIT_SHA=""
 
 # Sandbox configuration:
 SANDBOX_URL="https://github.com/algorand/sandbox"
-SANDBOX_BRANCH="config-max-account-lookback"
+SANDBOX_BRANCH="master"
 SANDBOX_CLEAN_CACHE=1
 LOCAL_SANDBOX_DIR=".sandbox"
 


### PR DESCRIPTION
Set new env variable input to sandbox spin up for setting algod's max account lookback to 4.